### PR TITLE
[SDPA-1207] Added content archive operation.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
         "drupal/m4032404": "^1.0-alpha4",
         "drupal/maxlength": "^1.0-beta2",
         "drupal/media_entity_audio": "^2.0-alpha1",
-        "drupal/metatag": "^1.7",
+        "drupal/metatag": "1.7",
         "drupal/override_node_options": "^2.4",
         "drupal/paragraphs": "^1.5",
         "drupal/password_policy": "dev-3.x",

--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,7 @@
         "drupal/m4032404": "^1.0-alpha4",
         "drupal/maxlength": "^1.0-beta2",
         "drupal/media_entity_audio": "^2.0-alpha1",
-        "drupal/metatag": "1.7",
+        "drupal/metatag": "^1.7",
         "drupal/override_node_options": "^2.4",
         "drupal/paragraphs": "^1.5",
         "drupal/password_policy": "dev-3.x",

--- a/src/Form/EntityArchiveForm.php
+++ b/src/Form/EntityArchiveForm.php
@@ -1,0 +1,141 @@
+<?php
+
+namespace Drupal\tide_core\Form;
+
+use Drupal\Core\Access\AccessResult;
+use Drupal\Core\Session\AccountInterface;
+use Drupal\Core\Form\ConfirmFormBase;
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\Messenger\MessengerInterface;
+use Drupal\Core\Url;
+use Drupal\workflows\Entity\Workflow;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Defines a confirmation form for archival of an entity.
+ */
+class EntityArchiveForm extends ConfirmFormBase {
+  /**
+   * The Workflow entity.
+   *
+   * @var \Drupal\Core\Entity\EntityInterface
+   */
+  protected $entity;
+
+  /**
+   * The Messenger service.
+   *
+   * @var \Drupal\Core\Messenger\MessengerInterface
+   */
+  protected $messenger;
+
+  /**
+   * Constructs an EntityArchiveForm object.
+   *
+   * @param \Drupal\Core\Messenger\MessengerInterface $messenger
+   *   The messenger service.
+   */
+  public function __construct(MessengerInterface $messenger) {
+    $this->messenger = $messenger;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container) {
+    return new static(
+      $container->get('messenger')
+    );
+  }
+
+  /**
+   * Checks access for a specific request.
+   *
+   * @param \Drupal\Core\Session\AccountInterface $account
+   *   Run access checks for this account.
+   * @param string $bundle
+   *   The configuration of the plugin.
+   * @param string $entity_type_id
+   *   The plugin id.
+   *
+   * @return \Drupal\Core\Access\AccessResultInterface
+   *   The access result.
+   */
+  public function access(AccountInterface $account, string $bundle = NULL, string $entity_type_id = NULL) {
+    // If entity does not exist then return right away.
+    if (!$this->entity = \Drupal::entityTypeManager()->getStorage($bundle)->load($entity_type_id)) {
+      return AccessResult::forbidden();
+    }
+    // Load Editorial workflow and check if it applies to given entity.
+    $workflow = Workflow::load('editorial');
+    if ($workflow) {
+      if ($workflow->getTypePlugin()
+        ->appliesToEntityTypeAndBundle($this->entity->getEntityTypeId(), $this->entity->bundle())) {
+        if ($this->entity->access('use ' . $workflow->id() . ' transition archived', $account)) {
+          return AccessResult::allowed();
+        }
+      }
+    }
+
+    return AccessResult::forbidden();
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function buildForm(array $form, FormStateInterface $form_state, string $bundle = NULL, string $entity_type_id = NULL) {
+    $this->entity = \Drupal::entityTypeManager()->getStorage($bundle)->load($entity_type_id);
+    return parent::buildForm($form, $form_state);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getFormId() {
+    return 'tide_core_entity_archive';
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getQuestion() {
+    return $this->t('Are you sure you want to archive entity %name?', ['%name' => $this->entity->label()]);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getDescription() {
+    return $this->t('This action will unpublish the content.');
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getCancelUrl() {
+    return Url::fromUserInput(\Drupal::destination()->get());
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getConfirmText() {
+    return $this->t('Archive');
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function submitForm(array &$form, FormStateInterface $form_state) {
+    $this->entity->set('moderation_state', 'archived');
+    $this->entity->save();
+
+    $this->messenger->addStatus($this->t('Content @type: Archived %label.', [
+      '@type' => $this->entity->bundle(),
+      '%label' => $this->entity->label(),
+    ]));
+
+    $form_state->setRedirectUrl($this->getCancelUrl());
+  }
+
+}

--- a/tests/behat/features/workflow.feature
+++ b/tests/behat/features/workflow.feature
@@ -230,6 +230,25 @@ Feature: Workflow states and transitions
     Then I should see the success message "[TEST] Editor Test title has been updated."
     And I should not see a "article.node--unpublished" element
 
+  @api @skipped
+  Scenario: Users with permission to Archive content can use Archive operation on content
+    Given test content:
+      | title                       | body | moderation_state |
+      | [TEST] Published article    | test | published        |
+    # Verify the Archive operation link is available.
+    Given I am logged in as a user with the administrator role
+    And I go to "admin/content"
+    Then the ".views-field views-field-operations" element should contain "Archive"
+    # Check the action.
+    When I click "Archive" in the "[TEST] Published article" row
+    Then I should see "This action will unpublish the content."
+    And I press "Archive"
+    Then I should see the success message containing "[TEST] Archived article"
+    # Verify the status of the
+    When I edit test "[TEST] Published article"
+    Then the response status code should be 200
+    And the "Current state" element should contain "Archived"
+
   @api
   Scenario: Previewer has access to unpublished content
 

--- a/tide_core.drush.inc
+++ b/tide_core.drush.inc
@@ -1,0 +1,37 @@
+<?php
+
+/**
+ * @file
+ * Drush commands for Tide Core.
+ */
+
+/**
+ * Implements hook_drush_command().
+ */
+function tide_core_drush_command() {
+  $items = [];
+
+  $items['tide-core-scheduled-updates-cron'] = [
+    'description' => 'Execute scheduled_updates cron.',
+    'examples' => [
+      'drush tide-core-scheduled-updates-cron' => dt('Run scheduled updates cron.'),
+    ],
+    'arguments' => [],
+    'aliases' => ['tide-su-cron'],
+  ];
+
+  return $items;
+}
+
+/**
+ * Execute scheduled_updates cron.
+ */
+function drush_tide_core_scheduled_updates_cron() {
+
+  try {
+    \Drupal::moduleHandler()->invoke('scheduled_updates', 'cron');
+  }
+  catch (ConsoleException $exception) {
+    drush_set_error($exception->getMessage());
+  }
+}

--- a/tide_core.module
+++ b/tide_core.module
@@ -5,8 +5,11 @@
  * Contains tide_core.module.
  */
 
+use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\Url;
 use Drupal\views\ViewExecutable;
+use Drupal\workflows\Entity\Workflow;
 
 /**
  * Implements hook_views_data_alter().
@@ -74,4 +77,27 @@ function tide_core_form_node_form_alter(&$form, FormStateInterface $form_state, 
       unset($form['scheduled_archiving']);
     }
   }
+}
+
+/**
+ * Implements hook_entity_operation().
+ */
+function tide_core_entity_operation(EntityInterface $entity) {
+  // Add "Archived" operation link to entities.
+  $operations = [];
+  $workflow = Workflow::load('editorial');
+  if ($workflow) {
+    if ($workflow->getTypePlugin()
+      ->appliesToEntityTypeAndBundle($entity->getEntityTypeId(), $entity->bundle())) {
+      if ($entity->access('use ' . $workflow->id() . ' transition archived')) {
+        $operations['archive'] = [
+          'title' => t('Archive'),
+          'weight' => 100,
+          'url' => Url::fromRoute('tide_core.entity.archive_confirm', ['bundle' => $entity->getEntityTypeId(), 'entity_type_id' => $entity->id()]),
+        ];
+      }
+    }
+  }
+
+  return $operations;
 }

--- a/tide_core.routing.yml
+++ b/tide_core.routing.yml
@@ -1,0 +1,7 @@
+tide_core.entity.archive_confirm:
+  path: '/admin/content/{bundle}/{entity_type_id}/archive'
+  defaults:
+    _form: '\Drupal\tide_core\Form\EntityArchiveForm'
+    _title: 'Confirm Archive'
+  requirements:
+    _custom_access: '\Drupal\tide_core\Form\EntityArchiveForm::access'


### PR DESCRIPTION
Story: https://digital-engagement.atlassian.net/browse/SDPA-1207

### Changed:
- Pinned Metatag module version to stop the patch breaking the build (known issue, see #57 )
- Added new custom confirmation Form for entity Archive operation.
- Added custom route that points to the confirmation form mentioned above.
- Added hook_entity_operation that adds the dropdown option "Archive"

### Note
- I was unsuccessful with adding Behat tests due to permissions that Workflow generates dynamically. The module checks for "use editorial transition archived" which does not seem to exist during Behat testing.

### Screenshots
![screen shot 2019-03-06 at 10 46 33 am](https://user-images.githubusercontent.com/7392927/53845539-9e806080-3ffd-11e9-8968-3982ce088443.png)
