### PR TITLE
[SDPA-3100]Altered the scheduled transition’s UI

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -52,7 +52,9 @@
         "drupal/viewsreference": "^2.0-alpha4",
         "drupal/wysiwyg_template": "^2.0@beta",
         "drupal/dynamic_entity_reference": "^1.7",
-        "drupal/scheduled_transitions": "^1.0"
+        "drupal/scheduled_transitions": "^1.0",
+        "drupal/content_moderation_scheduled_updates": "^1.0",
+        "drupal/scheduled_updates": "^1.0-alpha7"
     },
     "repositories": {
         "drupal": {

--- a/config/optional/workflows.workflow.editorial.yml
+++ b/config/optional/workflows.workflow.editorial.yml
@@ -32,6 +32,8 @@ type_settings:
     archive:
       label: Archive
       from:
+        - draft
+        - needs_review
         - published
       to: archived
       weight: -6
@@ -68,8 +70,6 @@ type_settings:
       weight: -8
     publish:
       label: Publish
-      to: published
-      weight: 1
       from:
         - draft
         - needs_review

--- a/src/EventSubscriber/TideCoreRouteAlter.php
+++ b/src/EventSubscriber/TideCoreRouteAlter.php
@@ -20,20 +20,13 @@ class TideCoreRouteAlter extends RouteSubscriberBase {
   protected function alterRoutes(RouteCollection $collection) {
     $route = $collection->get('entity.node.scheduled_transitions');
     if ($route) {
-      $route->setPath('/node/{node}/scheduled-publishing');
       $route->setDefault('_title', 'Scheduled publishing');
       $collection->add('entity.node.scheduled_transitions', $route);
     }
     $route = $collection->get('entity.node.scheduled_transition_add');
     if ($route) {
       $route->setDefault('_title', 'Add Scheduled publishing');
-      $route->setPath('/node/{node}/scheduled-publishing/add');
       $collection->add('entity.node.scheduled_transition_add', $route);
-    }
-    $route = $collection->get('entity.scheduled_transition.delete_form');
-    if ($route) {
-      $route->setPath('/admin/scheduled-publishing/{scheduled_transition}/delete');
-      $collection->add('entity.scheduled_transition.delete_form', $route);
     }
   }
 

--- a/src/EventSubscriber/TideCoreRouteAlter.php
+++ b/src/EventSubscriber/TideCoreRouteAlter.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Drupal\tide_core\EventSubscriber;
+
+use Drupal\Core\Routing\RouteSubscriberBase;
+use Symfony\Component\Routing\RouteCollection;
+
+/**
+ * Class TideCoreRouteAlter.
+ *
+ * @package Drupal\tide_core
+ */
+class TideCoreRouteAlter extends RouteSubscriberBase {
+
+  /**
+   * Alter scheduled_transitions route and path.
+   *
+   * {@inheritDoc}.
+   */
+  protected function alterRoutes(RouteCollection $collection) {
+    $route = $collection->get('entity.node.scheduled_transitions');
+    if ($route) {
+      $route->setPath('/node/{node}/scheduled-publishing');
+      $route->setDefault('_title', 'Scheduled publishing');
+      $collection->add('entity.node.scheduled_transitions', $route);
+    }
+    $route = $collection->get('entity.node.scheduled_transition_add');
+    if ($route) {
+      $route->setDefault('_title', 'Add Scheduled publishing');
+      $route->setPath('/node/{node}/scheduled-publishing/add');
+      $collection->add('entity.node.scheduled_transition_add', $route);
+    }
+    $route = $collection->get('entity.scheduled_transition.delete_form');
+    if ($route) {
+      $route->setPath('/admin/scheduled-publishing/{scheduled_transition}/delete');
+      $collection->add('entity.scheduled_transition.delete_form', $route);
+    }
+  }
+
+}

--- a/src/EventSubscriber/TideCoreRouteAlter.php
+++ b/src/EventSubscriber/TideCoreRouteAlter.php
@@ -20,13 +20,11 @@ class TideCoreRouteAlter extends RouteSubscriberBase {
   protected function alterRoutes(RouteCollection $collection) {
     $route = $collection->get('entity.node.scheduled_transitions');
     if ($route) {
-      $route->setDefault('_title', 'Scheduled publishing');
-      $collection->add('entity.node.scheduled_transitions', $route);
+      $route->setDefault('_title', 'Scheduled updates');
     }
     $route = $collection->get('entity.node.scheduled_transition_add');
     if ($route) {
-      $route->setDefault('_title', 'Add Scheduled publishing');
-      $collection->add('entity.node.scheduled_transition_add', $route);
+      $route->setDefault('_title', 'Add Scheduled update');
     }
   }
 

--- a/tide_core.install
+++ b/tide_core.install
@@ -292,3 +292,13 @@ function tide_core_update_8009() {
   batch_set($batch);
   batch_process();
 }
+
+/**
+ * Enable scheduled_transitions module.
+ */
+function tide_core_update_8010() {
+  if (!\Drupal::moduleHandler()->moduleExists('scheduled_transitions')) {
+    $module_installer = \Drupal::service('module_installer');
+    $module_installer->install(['scheduled_transitions']);
+  }
+}

--- a/tide_core.links.task.yml
+++ b/tide_core.links.task.yml
@@ -1,0 +1,4 @@
+tide_core.scheduled_publishing:
+  title: Scheduled publishing
+  route_name: entity.scheduled_transition.collection
+  base_route: system.admin_content

--- a/tide_core.links.task.yml
+++ b/tide_core.links.task.yml
@@ -1,4 +1,4 @@
-tide_core.scheduled_publishing:
-  title: Scheduled publishing
+tide_core.scheduled_update:
+  title: Scheduled updates
   route_name: entity.scheduled_transition.collection
   base_route: system.admin_content

--- a/tide_core.module
+++ b/tide_core.module
@@ -7,8 +7,10 @@
 
 use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Url;
+use Drupal\scheduled_transitions\Routing\ScheduledTransitionsRouteProvider;
 use Drupal\views\ViewExecutable;
 use Drupal\workflows\Entity\Workflow;
+use Drupal\Core\Form\FormStateInterface;
 
 /**
  * Implements hook_views_data_alter().
@@ -58,6 +60,85 @@ function tide_core_entity_operation(EntityInterface $entity) {
       }
     }
   }
+  if (\Drupal::moduleHandler()->moduleExists('scheduled_transitions') && $entity->getEntityType()->hasLinkTemplate(ScheduledTransitionsRouteProvider::LINK_TEMPLATE_ADD)) {
+    $routeName = ScheduledTransitionsRouteProvider::getScheduledTransitionRouteName($entity->getEntityType());
+    $url = Url::fromRoute($routeName, [$entity->getEntityTypeId() => $entity->id()]);
+    $user = \Drupal::currentUser();
+    if (TRUE === $url->access($user)) {
+      $operations['scheduled_transitions'] = [
+        'title' => \t('Scheduled publishing'),
+        'url' => $url,
+        'weight' => 50,
+      ];
+    }
+  }
 
   return $operations;
+}
+
+/**
+ * Implements hook_form_alter().
+ */
+function tide_core_form_alter(&$form, FormStateInterface $form_state, $form_id) {
+  $info = \Drupal::service('entity_type.bundle.info');
+  foreach ($info->getBundleInfo('node') as $bundle => $item) {
+    if ($form_id == 'node_' . $bundle . '_scheduled_transitions_add_form_form') {
+      if (isset($form['scheduled_transitions']['new_meta']['state']['#options'])) {
+        foreach ($form['scheduled_transitions']['new_meta']['state']['#options'] as $key => $option) {
+          if (!in_array($key, ['published', 'archived'])) {
+            unset($form['scheduled_transitions']['new_meta']['state']['#options'][$key]);
+          }
+        }
+      }
+      foreach (array_keys($form['actions']) as $action) {
+        if ($action != 'preview' && isset($form['actions'][$action]['#type']) && $form['actions'][$action]['#type'] === 'submit') {
+          $form['actions'][$action]['#value'] = \t('Schedule publishing');
+          $form['actions'][$action]['#submit'][] = '_tide_core_modified_publishing_adding_message';
+        }
+      }
+    }
+  }
+}
+
+/**
+ * Implements hook_form_FORM_ID_alter().
+ */
+function tide_core_form_scheduled_transition_delete_form_alter(&$form, FormStateInterface $form_state, $form_id) {
+  $form['#title'] = \t('Are you sure you want to delete the scheduled publishing?');
+  foreach (array_keys($form['actions']) as $action) {
+    if ($action != 'preview' && isset($form['actions'][$action]['#type']) && $form['actions'][$action]['#type'] === 'submit') {
+      $form['actions'][$action]['#submit'][] = '_tide_core_modified_publishing_delete_message';
+    }
+  }
+}
+
+/**
+ * Submit handler for altering publishing status message.
+ */
+function _tide_core_modified_publishing_adding_message(&$form, $form_state) {
+  $messenger = \Drupal::messenger();
+  $messenger->deleteByType('status');
+  $onDate = $form_state->getValue(['on']);
+  $messenger->addMessage(\t('Scheduled a publishing for @date', [
+    '@date' => \Drupal::service('date.formatter')
+      ->format($onDate->getTimestamp()),
+  ]));
+}
+
+/**
+ * Submit handler for altering deleting status message.
+ */
+function _tide_core_modified_publishing_delete_message(&$form, $form_state) {
+  $messenger = \Drupal::messenger();
+  $messenger->deleteByType('status');
+  $messenger->addMessage(\t('The scheduled publishing has been deleted.'), 'status');
+}
+
+/**
+ * Implements hook_menu_links_discovered_alter().
+ */
+function tide_core_menu_links_discovered_alter(&$links) {
+  if (isset($links['entity.scheduled_transition.collection']['title'])) {
+    $links['entity.scheduled_transition.collection']['title'] = 'Scheduled publishing';
+  }
 }

--- a/tide_core.module
+++ b/tide_core.module
@@ -60,13 +60,13 @@ function tide_core_entity_operation(EntityInterface $entity) {
       }
     }
   }
-  if (\Drupal::moduleHandler()->moduleExists('scheduled_transitions') && $entity->getEntityType()->hasLinkTemplate(ScheduledTransitionsRouteProvider::LINK_TEMPLATE_ADD)) {
+  if ($entity->getEntityType()->hasLinkTemplate(ScheduledTransitionsRouteProvider::LINK_TEMPLATE_ADD)) {
     $routeName = ScheduledTransitionsRouteProvider::getScheduledTransitionRouteName($entity->getEntityType());
     $url = Url::fromRoute($routeName, [$entity->getEntityTypeId() => $entity->id()]);
     $user = \Drupal::currentUser();
     if (TRUE === $url->access($user)) {
       $operations['scheduled_transitions'] = [
-        'title' => t('Scheduled publishing'),
+        'title' => t('Scheduled updates'),
         'url' => $url,
         'weight' => 50,
       ];
@@ -84,7 +84,10 @@ function tide_core_form_alter(&$form, FormStateInterface $form_state, $form_id) 
   foreach ($info->getBundleInfo('node') as $bundle => $item) {
     if ($form_id == 'node_' . $bundle . '_scheduled_transitions_add_form_form') {
       if (isset($form['scheduled_transitions']['new_meta']['state']['#options'])) {
-        foreach ($form['scheduled_transitions']['new_meta']['state']['#options'] as $key => $option) {
+        foreach ($form['scheduled_transitions']['new_meta']['state']['#options'] as $key => &$option) {
+          if ($option == 'Restore') {
+            $option = 'Published';
+          }
           if (!in_array($key, ['published', 'archived'])) {
             unset($form['scheduled_transitions']['new_meta']['state']['#options'][$key]);
           }
@@ -92,8 +95,8 @@ function tide_core_form_alter(&$form, FormStateInterface $form_state, $form_id) 
       }
       foreach (array_keys($form['actions']) as $action) {
         if ($action != 'preview' && isset($form['actions'][$action]['#type']) && $form['actions'][$action]['#type'] === 'submit') {
-          $form['actions'][$action]['#value'] = t('Schedule publishing');
-          $form['actions'][$action]['#submit'][] = '_tide_core_modified_publishing_adding_message';
+          $form['actions'][$action]['#value'] = t('Scheduled updates');
+          $form['actions'][$action]['#submit'][] = '_tide_core_modified_update_adding_message';
         }
       }
     }
@@ -104,22 +107,22 @@ function tide_core_form_alter(&$form, FormStateInterface $form_state, $form_id) 
  * Implements hook_form_FORM_ID_alter().
  */
 function tide_core_form_scheduled_transition_delete_form_alter(&$form, FormStateInterface $form_state, $form_id) {
-  $form['#title'] = t('Are you sure you want to delete the scheduled publishing?');
+  $form['#title'] = t('Are you sure you want to delete the Scheduled updates?');
   foreach (array_keys($form['actions']) as $action) {
     if ($action != 'preview' && isset($form['actions'][$action]['#type']) && $form['actions'][$action]['#type'] === 'submit') {
-      $form['actions'][$action]['#submit'][] = '_tide_core_modified_publishing_delete_message';
+      $form['actions'][$action]['#submit'][] = '_tide_core_modified_update_delete_message';
     }
   }
 }
 
 /**
- * Submit handler for altering publishing status message.
+ * Submit handler for altering updating status message.
  */
-function _tide_core_modified_publishing_adding_message(&$form, $form_state) {
+function _tide_core_modified_update_adding_message(&$form, $form_state) {
   $messenger = \Drupal::messenger();
   $messenger->deleteByType('status');
   $onDate = $form_state->getValue(['on']);
-  $messenger->addMessage(t('Scheduled a publishing for @date', [
+  $messenger->addMessage(t('Scheduled an update for @date', [
     '@date' => \Drupal::service('date.formatter')
       ->format($onDate->getTimestamp()),
   ]));
@@ -128,10 +131,10 @@ function _tide_core_modified_publishing_adding_message(&$form, $form_state) {
 /**
  * Submit handler for altering deleting status message.
  */
-function _tide_core_modified_publishing_delete_message(&$form, $form_state) {
+function _tide_core_modified_update_delete_message(&$form, $form_state) {
   $messenger = \Drupal::messenger();
   $messenger->deleteByType('status');
-  $messenger->addMessage(t('The scheduled publishing has been deleted.'), 'status');
+  $messenger->addMessage(t('The Scheduled update has been deleted.'), 'status');
 }
 
 /**
@@ -139,6 +142,24 @@ function _tide_core_modified_publishing_delete_message(&$form, $form_state) {
  */
 function tide_core_menu_links_discovered_alter(&$links) {
   if (isset($links['entity.scheduled_transition.collection']['title'])) {
-    $links['entity.scheduled_transition.collection']['title'] = 'Scheduled publishing';
+    $links['entity.scheduled_transition.collection']['title'] = 'Scheduled updates';
+  }
+}
+
+/**
+ * Implements hook_menu_local_actions_alter().
+ */
+function tide_core_menu_local_actions_alter(&$local_actions) {
+  if (isset($local_actions['scheduled_transitions.actions:node.add_scheduled_transition']['title'])) {
+    $local_actions['scheduled_transitions.actions:node.add_scheduled_transition']['title'] = 'Add Scheduled update';
+  }
+}
+
+/**
+ * Implements hook_local_tasks_alter().
+ */
+function tide_core_local_tasks_alter(&$local_tasks) {
+  if (isset($local_tasks['scheduled_transitions.tasks:node.scheduled_transitions']['title'])) {
+    $local_tasks['scheduled_transitions.tasks:node.scheduled_transitions']['title'] = 'Scheduled updates';
   }
 }

--- a/tide_core.module
+++ b/tide_core.module
@@ -66,7 +66,7 @@ function tide_core_entity_operation(EntityInterface $entity) {
     $user = \Drupal::currentUser();
     if (TRUE === $url->access($user)) {
       $operations['scheduled_transitions'] = [
-        'title' => \t('Scheduled publishing'),
+        'title' => t('Scheduled publishing'),
         'url' => $url,
         'weight' => 50,
       ];
@@ -92,7 +92,7 @@ function tide_core_form_alter(&$form, FormStateInterface $form_state, $form_id) 
       }
       foreach (array_keys($form['actions']) as $action) {
         if ($action != 'preview' && isset($form['actions'][$action]['#type']) && $form['actions'][$action]['#type'] === 'submit') {
-          $form['actions'][$action]['#value'] = \t('Schedule publishing');
+          $form['actions'][$action]['#value'] = t('Schedule publishing');
           $form['actions'][$action]['#submit'][] = '_tide_core_modified_publishing_adding_message';
         }
       }
@@ -104,7 +104,7 @@ function tide_core_form_alter(&$form, FormStateInterface $form_state, $form_id) 
  * Implements hook_form_FORM_ID_alter().
  */
 function tide_core_form_scheduled_transition_delete_form_alter(&$form, FormStateInterface $form_state, $form_id) {
-  $form['#title'] = \t('Are you sure you want to delete the scheduled publishing?');
+  $form['#title'] = t('Are you sure you want to delete the scheduled publishing?');
   foreach (array_keys($form['actions']) as $action) {
     if ($action != 'preview' && isset($form['actions'][$action]['#type']) && $form['actions'][$action]['#type'] === 'submit') {
       $form['actions'][$action]['#submit'][] = '_tide_core_modified_publishing_delete_message';
@@ -119,7 +119,7 @@ function _tide_core_modified_publishing_adding_message(&$form, $form_state) {
   $messenger = \Drupal::messenger();
   $messenger->deleteByType('status');
   $onDate = $form_state->getValue(['on']);
-  $messenger->addMessage(\t('Scheduled a publishing for @date', [
+  $messenger->addMessage(t('Scheduled a publishing for @date', [
     '@date' => \Drupal::service('date.formatter')
       ->format($onDate->getTimestamp()),
   ]));
@@ -131,7 +131,7 @@ function _tide_core_modified_publishing_adding_message(&$form, $form_state) {
 function _tide_core_modified_publishing_delete_message(&$form, $form_state) {
   $messenger = \Drupal::messenger();
   $messenger->deleteByType('status');
-  $messenger->addMessage(\t('The scheduled publishing has been deleted.'), 'status');
+  $messenger->addMessage(t('The scheduled publishing has been deleted.'), 'status');
 }
 
 /**

--- a/tide_core.services.yml
+++ b/tide_core.services.yml
@@ -1,0 +1,5 @@
+services:
+  tide_core.event_subscriber:
+    class: Drupal\tide_core\EventSubscriber\TideCoreRouteAlter
+    tags:
+      - { name: event_subscriber }


### PR DESCRIPTION
https://digital-engagement.atlassian.net/projects/SDPA/issues/SDPA-3100

Change 'Scheduled transitions' to 'Scheduled updates publishing' on the following: 

Scheduled transitions page ( https://nginx-php-content-vic-pr-616.lagoon.vicsdp.amazee.io/admin/content/scheduled-transitions)

Within the content menu

Content summary page when selecting operations dropdown next to each content summary

In the 'Execute transitions' dropdown hide all options except for 'Publish' and Archive'.

'Scheduled updates ' tab should also be available to the content tab. 