### PR TITLE
[SDPA-3231] moved timelines config to tide_core

### DIFF
--- a/tide_core.info.yml
+++ b/tide_core.info.yml
@@ -144,8 +144,6 @@ config_devel:
     - metatag.metatag_defaults.node
     - metatag.metatag_defaults.taxonomy_term
     - metatag.metatag_defaults.user
-    - paragraphs.paragraphs_type.timeline
-    - paragraphs.paragraphs_type.timelines
     - pathauto.pattern.content_title
     - pathauto.settings
     - prlp.settings


### PR DESCRIPTION
https://digital-engagement.atlassian.net/browse/SDPA-3231

removed 
     - paragraphs.paragraphs_type.timeline	
     - paragraphs.paragraphs_type.timelines
related PRs:
https://github.com/dpc-sdp/content-vic-gov-au/pull/708
https://github.com/dpc-sdp/tide_landing_page/pull/86