### PR TITLE
[SDPA-3015] adds link_field_autocomplete_filter

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -54,7 +54,8 @@
         "drupal/dynamic_entity_reference": "^1.7",
         "drupal/scheduled_transitions": "^1.0",
         "drupal/content_moderation_scheduled_updates": "^1.0",
-        "drupal/scheduled_updates": "^1.0-alpha7"
+        "drupal/scheduled_updates": "^1.0-alpha7",
+        "drupal/link_field_autocomplete_filter": "^1.8"
     },
     "repositories": {
         "drupal": {

--- a/tide_core.install
+++ b/tide_core.install
@@ -362,3 +362,13 @@ function tide_core_update_8013() {
     $role->save();
   }
 }
+
+/**
+ * Enable link_field_autocomplete_filter module.
+ */
+function tide_core_update_8014() {
+  if (!\Drupal::moduleHandler()->moduleExists('link_field_autocomplete_filter')) {
+    $module_installer = \Drupal::service('module_installer');
+    $module_installer->install(['link_field_autocomplete_filter']);
+  }
+}


### PR DESCRIPTION
# Description 
adds `link_field_autocomplete_filter` module so that link field type can have a UI for exporting configuration.

https://digital-engagement.atlassian.net/browse/SDPA-3015

# Changes
1. `link_field_autocomplete_filter` looks nice and it should be added into tide_core module so that all link type have config UI if needed.
2. in this PR we don't have any yml configs, because there are no default configs for enabling `link_field_autocomplete_filter` module. users should set the config under an actual site.


![image](https://user-images.githubusercontent.com/8788145/65562039-1ad19580-df88-11e9-914f-f0c9f895a7da.png)
