### PR TITLE
[SDPA-3354] Moved field_call_to_action definition to tide_core.

### DIFF
--- a/config/install/field.storage.node.field_call_to_action.yml
+++ b/config/install/field.storage.node.field_call_to_action.yml
@@ -1,0 +1,18 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - link
+    - node
+id: node.field_call_to_action
+field_name: field_call_to_action
+entity_type: node
+type: link
+settings: {  }
+module: link
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false


### PR DESCRIPTION
### Changes
Moves field_call_to_action definition to tide_core because it's shared across modules.

### Related PRs
dpc-sdp/content-vic-gov-au#
dpc-sdp/tide#78
dpc-sdp/tide_alert#