### PR TITLE
Added version constraint for entity_reference_revisions.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,6 +20,7 @@
         "drupal/diff": "^1.0-RC2",
         "drupal/editor_advanced_link": "^1.4",
         "drupal/entity_browser": "^1.6",
+        "drupal/entity_reference_revisions": "~1.6.0",
         "drupal/entity_embed": "^1.0.0-beta2",
         "drupal/environment_indicator": "^3.5",
         "drupal/events_log_track": "^1.1",

--- a/dev-tools.sh
+++ b/dev-tools.sh
@@ -33,6 +33,6 @@
 # stable version.
 #
 # Uncomment and set the Dev-Tools's commit value and commit this change.
-# export GH_COMMIT=COMMIT_SHA
+export GH_COMMIT=96ae41bcdda3becfda4552d858025dc69799ff67
 
 bash <(curl -L https://raw.githubusercontent.com/dpc-sdp/dev-tools/master/install?"$(date +%s)") "$@"

--- a/dev-tools.sh
+++ b/dev-tools.sh
@@ -33,6 +33,6 @@
 # stable version.
 #
 # Uncomment and set the Dev-Tools's commit value and commit this change.
-export GH_COMMIT=1808fe0413005a20ef37ebd4f8d2d8be9a4fa408
+# export GH_COMMIT=COMMIT_SHA
 
 bash <(curl -L https://raw.githubusercontent.com/dpc-sdp/dev-tools/master/install?"$(date +%s)") "$@"

--- a/dev-tools.sh
+++ b/dev-tools.sh
@@ -33,6 +33,6 @@
 # stable version.
 #
 # Uncomment and set the Dev-Tools's commit value and commit this change.
-export GH_COMMIT=96ae41bcdda3becfda4552d858025dc69799ff67
+export GH_COMMIT=1808fe0413005a20ef37ebd4f8d2d8be9a4fa408
 
 bash <(curl -L https://raw.githubusercontent.com/dpc-sdp/dev-tools/master/install?"$(date +%s)") "$@"


### PR DESCRIPTION
https://digital-engagement.atlassian.net/browse/SDPA-3451

### Changed
1. Updated dpc-sdp/tide_core to constrain versions of entity_reference_revisions < 1.6.x

### Related PRs
dpc-sdp/content-vic-gov-au#740