### PR TITLE
SDPA-3505 Turn off ClamAV tcpip mode in tide_core

### DIFF
--- a/config/optional/clamav.settings.yml
+++ b/config/optional/clamav.settings.yml
@@ -1,7 +1,7 @@
 enabled: true
 outage_action: 0
 overridden_schemes: {  }
-scan_mode: 0
+scan_mode: 1
 verbosity: 0
 mode_executable:
   executable_path: /usr/bin/clamscan


### PR DESCRIPTION
### Jira
https://digital-engagement.atlassian.net/browse/SDPA-3505
### Changes
- change `scan_mode` in clamav.settings.yml to 1
### Issue
I think there is no way to split the configs from module level. the module only has `install` and `option` folder. 
Changing `scan_mode` based on `environment` should happen in global config folder like `config/ci`, `config/dev` `config/local` ?
### Question
does CI get ClamAV installed under /usr/bin/...?