### PR TITLE
[SDPA-3506] override content_moderation css

### DIFF
--- a/css/content_moderation.module.css
+++ b/css/content_moderation.module.css
@@ -1,0 +1,36 @@
+/**
+ * @file
+ * Component styles for the content_moderation module.
+ */
+.entity-moderation-form {
+  list-style: none;
+  -webkit-flex-wrap: wrap; /* Safari */
+  flex-wrap: wrap;
+  -webkit-align-items: flex-start; /* Safari */
+  align-items: flex-start;
+}
+
+.entity-moderation-form__item {
+  margin-right: 2em;
+  display: table;
+}
+
+.entity-moderation-form__item:last-child {
+  -webkit-align-self: flex-end; /* Safari */
+  align-self: flex-end;
+  margin-right: 0;
+}
+
+.entity-moderation-form .form-item {
+  margin-top: 1em;
+  margin-bottom: 1em;
+}
+
+.entity-moderation-form .form-item label {
+  padding-bottom: 0.25em;
+  display: table;
+}
+
+.entity-moderation-form input[type=submit] {
+  margin-bottom: 1.2em;
+}

--- a/css/content_moderation.theme.css
+++ b/css/content_moderation.theme.css
@@ -1,0 +1,10 @@
+/**
+ * @file
+ * Theme styles for the content_moderation module.
+ */
+.entity-moderation-form {
+  border: 1px dashed #bbb;
+  margin: 2em 0;
+  background: #fff;
+  padding-left: 1em;
+}

--- a/tide_core.libraries.yml
+++ b/tide_core.libraries.yml
@@ -1,0 +1,7 @@
+content_moderation:
+  version: VERSION
+  css:
+    component:
+      css/content_moderation.module.css: {}
+    theme:
+      css/content_moderation.theme.css: {}

--- a/tide_core.module
+++ b/tide_core.module
@@ -189,3 +189,16 @@ function tide_core_entity_bundle_create($entity_type_id, $bundle) {
     }
   }
 }
+
+/**
+ * Implements hook_form_FORM_ID_alter().
+ */
+function vicgovau_core_form_content_moderation_entity_moderation_form_alter(&$form, FormStateInterface $form_state, $form_id) {
+  // @todo It should implement libraries-override key under a custom theme, but we don't have custom theme.
+  // Just override content_moderation css library.
+  $form['#attached']['library'] = 'tide_core/content_moderation';
+  $form['revision_log']['#type'] = 'textarea';
+  $form['revision_log']['#title'] = t('Publishing instructions and comments');
+  $form['revision_log']['#description'] = t('All content will be published within 24 hours. State below if your content is embargoed or time critical.');
+  $form['new_state']['#title'] = t('Change status to');
+}

--- a/tide_core.module
+++ b/tide_core.module
@@ -193,9 +193,7 @@ function tide_core_entity_bundle_create($entity_type_id, $bundle) {
 /**
  * Implements hook_form_FORM_ID_alter().
  */
-function vicgovau_core_form_content_moderation_entity_moderation_form_alter(&$form, FormStateInterface $form_state, $form_id) {
-  // @todo It should implement libraries-override key under a custom theme, but we don't have custom theme.
-  // Just override content_moderation css library.
+function tide_core_form_content_moderation_entity_moderation_form_alter(&$form, FormStateInterface $form_state, $form_id) {
   $form['#attached']['library'] = 'tide_core/content_moderation';
   $form['revision_log']['#type'] = 'textarea';
   $form['revision_log']['#title'] = t('Publishing instructions and comments');


### PR DESCRIPTION
### Issue
As a Site Administrator, I would like the log message text field title and help text to change so that it clearly describes what the text field is used for. 

### jira
https://digital-engagement.atlassian.net/browse/SDPA-3506

### Changes
- alter content_moderation_entity_moderation_form form in by implementing a form_alter .
- change $form['revision_log']['#type']=['textfield'] to $form['revision_log']['#type']=['textarea']
- change $form['new_state'] to `Change status to`
- add a  #description form attr to $form['revision_log'] and set the value to be `All content will be published within 24 hours. State below if your content is embargoed or time critical'`

- aligning the forms to be a vertical form by overriding  `content_moderation.module.css`.

![image](https://user-images.githubusercontent.com/8788145/69513138-e59eef00-0f9a-11ea-824e-f6cdba91aac8.png)

### relevant
https://github.com/dpc-sdp/content-vic-gov-au/pull/749