### PR TITLE
fixing building failing issue

### DIFF
--- a/dev-tools.sh
+++ b/dev-tools.sh
@@ -33,6 +33,6 @@
 # stable version.
 #
 # Uncomment and set the Dev-Tools's commit value and commit this change.
-export GH_COMMIT=08030a69a651ad270e4d5328c69a341c21855f94
+export GH_COMMIT=a06d079ad232a38cf4cc39feaa4dd8f1df3fe9e2
 
 bash <(curl -L https://raw.githubusercontent.com/dpc-sdp/dev-tools/master/install?"$(date +%s)") "$@"

--- a/tide_core.info.yml
+++ b/tide_core.info.yml
@@ -29,6 +29,7 @@ dependencies:
   - drupal:text
   - drupal:user
   - drupal:workflows
+  - drupal:hal
   - editor_advanced_link:editor_advanced_link
   - entity_browser:entity_browser
   - entity_browser:entity_browser_entity_form


### PR DESCRIPTION
in https://github.com/dpc-sdp/dev-tools/blob/feature/SDPA-3272-update-drupal-8-7/composer.dev.json#L9 branch it requires drupal/core 8.7.6 (commit: https://github.com/dpc-sdp/dev-tools/commit/8571a52b49c0321746cc376b594af602b2cc0b0b), but in tide_core we are using 8.7.9, which is a conflict. 
for fixing this issue, I created a new branch in dev-tools(https://github.com/dpc-sdp/dev-tools/tree/feature/SDPA-3272-update-drupal-to-8-7-9) which is using drupal/core 8.7.9.
