### PR TITLE
Bump Drupal Core to 8.7.11

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -94,9 +94,6 @@
                 "Add handlers for file and media entities - https://www.drupal.org/project/events_log_track/issues/2959769": "https://www.drupal.org/files/issues/2018-06-26/events-log-track_add-file-media-2959769-9.patch",
                 "Skip password logging during failed authentication attempt - https://www.drupal.org/project/events_log_track/issues/3027463": "https://www.drupal.org/files/issues/2019-01-22/event-log-track-auth-3027463-2.patch"
             },
-            "drupal/config_ignore": {
-                "Offset error within IgnoreFilter::activeReadMultiple() - https://www.drupal.org/project/config_ignore/issues/2972302": "https://www.drupal.org/files/issues/2018-06-05/offset-error-within-2972302-6.patch"
-            },
             "drupal/field_group": {
                 "Do not translate field group labels using interface translation. - https://www.drupal.org/project/field_group/issues/2846617": "https://www.drupal.org/files/issues/2019-04-18/field_group-use_config_translation-2846617-26.patch"
             },

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         "drupal/config_ignore": "^2.1",
         "drupal/config_split": "^1.4",
         "drupal/config_update": "^1.6",
-        "drupal/core": "8.7.9",
+        "drupal/core": "8.7.11",
         "drupal/diff": "^1.0-RC2",
         "drupal/editor_advanced_link": "^1.4",
         "drupal/entity_browser": "^1.6",

--- a/dev-tools.sh
+++ b/dev-tools.sh
@@ -33,6 +33,6 @@
 # stable version.
 #
 # Uncomment and set the Dev-Tools's commit value and commit this change.
-export GH_COMMIT=a06d079ad232a38cf4cc39feaa4dd8f1df3fe9e2
+export GH_COMMIT=eade89171ec349c8a49c47cf94820b1724f033bf
 
 bash <(curl -L https://raw.githubusercontent.com/dpc-sdp/dev-tools/master/install?"$(date +%s)") "$@"


### PR DESCRIPTION
### Changed
1.  Bumped version of Drupal Core 8.7.11

### Related PRs
dpc-sdp/content-vic-gov-au#760
dpc-sdp/tide#86