### PR TITLE
[SDPA-4029] revokes permission

### DIFF
--- a/config/install/user.role.approver.yml
+++ b/config/install/user.role.approver.yml
@@ -24,7 +24,6 @@ permissions:
   - 'administer menu'
   - 'administer redirect settings'
   - 'administer redirects'
-  - 'administer taxonomy'
   - 'administer url aliases'
   - 'administer webform'
   - 'administer webform element access'
@@ -152,3 +151,4 @@ permissions:
   - 'view test revisions'
   - 'view the administration theme'
   - 'view timeline revisions'
+  - 'access taxonomy overview'

--- a/config/install/user.role.site_admin.yml
+++ b/config/install/user.role.site_admin.yml
@@ -26,7 +26,6 @@ permissions:
   - 'administer menu'
   - 'administer redirect settings'
   - 'administer redirects'
-  - 'administer taxonomy'
   - 'administer url aliases'
   - 'administer users'
   - 'administer webform'
@@ -151,3 +150,4 @@ permissions:
   - 'view section_page revisions'
   - 'view the administration theme'
   - 'view timeline revisions'
+  - 'access taxonomy overview'

--- a/tide_core.install
+++ b/tide_core.install
@@ -442,3 +442,17 @@ function tide_core_update_8018() {
   $config->set('display.default.display_options.empty.area.content.value', 'There are no scheduled updates yet.');
   $config->save();
 }
+
+/**
+ * Change permissions.
+ *
+ * Revokes 'administer taxonomy' permission from site_admin and approver roles,
+ * and grants them 'access taxonomy overview'.
+ */
+function tide_core_update_8019() {
+  $roles = ['approver', 'site_admin'];
+  foreach ($roles as $role_id) {
+    user_role_revoke_permissions($role_id, ['administer taxonomy']);
+    user_role_grant_permissions($role_id, ['access taxonomy overview']);
+  }
+}

--- a/tide_core.install
+++ b/tide_core.install
@@ -14,6 +14,7 @@ use Drupal\field\Entity\FieldStorageConfig;
 use Drupal\field\Entity\FieldConfig;
 use Drupal\scheduled_transitions\ScheduledTransitionsPermissions;
 use Drupal\user\Entity\Role;
+use Drupal\taxonomy\TaxonomyPermissions;
 
 /**
  * Implements hook_install().
@@ -451,8 +452,16 @@ function tide_core_update_8018() {
  */
 function tide_core_update_8019() {
   $roles = ['approver', 'site_admin'];
+  $taxonomy_permissions = new TaxonomyPermissions(\Drupal::entityManager());
   foreach ($roles as $role_id) {
+    $assigned_permissions = ['access taxonomy overview'];
+    foreach ($taxonomy_permissions->permissions() as $permission => $details) {
+      $exploded = explode(' ', trim($permission));
+      if ($exploded[0] != 'delete') {
+        $assigned_permissions[] = $permission;
+      }
+    }
     user_role_revoke_permissions($role_id, ['administer taxonomy']);
-    user_role_grant_permissions($role_id, ['access taxonomy overview']);
+    user_role_grant_permissions($role_id, $assigned_permissions);
   }
 }


### PR DESCRIPTION
## JIRA
https://digital-engagement.atlassian.net/browse/SDPA-4029

## CHANGES
1. delete `administer taxonomy` from yml files.
2. add `access taxonomy overview` to yml files.
3. an hook_update for revoking  `administer taxonomy`  and granting `access taxonomy overview` from drupal site
4.  approver and site_admin both can still edit or create new terms.

https://github.com/dpc-sdp/content-vic-gov-au/pull/847