### PR TITLE
[SDPA-4174] lock drupal/token to 1.6

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -57,7 +57,8 @@
         "drupal/content_moderation_scheduled_updates": "^1.0",
         "drupal/scheduled_updates": "^1.0-alpha7",
         "drupal/link_field_autocomplete_filter": "^1.8",
-        "drupal/queue_mail": "^1.0"
+        "drupal/queue_mail": "^1.0",
+        "drupal/token": "1.6.0"
     },
     "repositories": {
         "drupal": {

--- a/tide_core.info.yml
+++ b/tide_core.info.yml
@@ -30,6 +30,7 @@ dependencies:
   - drupal:user
   - drupal:workflows
   - drupal:hal
+  - drupal:token
   - editor_advanced_link:editor_advanced_link
   - entity_browser:entity_browser
   - entity_browser:entity_browser_entity_form


### PR DESCRIPTION
## Jira
https://digital-engagement.atlassian.net/browse/SDPA-4174

## Changes
1. add drupal/token as a new dependency.