### PR TITLE
[SDPA-4203] only keep publish and archive

### DIFF
--- a/tide_core.module
+++ b/tide_core.module
@@ -86,13 +86,12 @@ function tide_core_form_alter(&$form, FormStateInterface $form_state, $form_id) 
   $info = \Drupal::service('entity_type.bundle.info');
   foreach ($info->getBundleInfo('node') as $bundle => $item) {
     if ($form_id == 'node_' . $bundle . '_scheduled_transitions_add_form_form') {
-      if (isset($form['scheduled_transitions']['new_meta']['state']['#options'])) {
-        foreach ($form['scheduled_transitions']['new_meta']['state']['#options'] as $key => &$option) {
-          if ($option == 'Restore') {
-            $option = 'Published';
-          }
-          if (!in_array($key, ['published', 'archived'])) {
-            unset($form['scheduled_transitions']['new_meta']['state']['#options'][$key]);
+      // In this form, we only keep 'publish' and 'archive' options regardless
+      // of what permissions the user has.
+      if (isset($form['scheduled_transitions']['new_meta']['transition']['#options'])) {
+        foreach ($form['scheduled_transitions']['new_meta']['transition']['#options'] as $key => $option) {
+          if (!in_array($key, ['publish', 'archive'])) {
+            unset($form['scheduled_transitions']['new_meta']['transition']['#options'][$key]);
           }
         }
       }


### PR DESCRIPTION
### Jira
https://digital-engagement.atlassian.net/browse/SDPA-4203

### Issue
we cannot achieve the requirement by manipulating permissions as the required logic is only applied to `'node_' . $bundle . '_scheduled_transitions_add_form_form'`, so simply altering the form.

### Changes
1. scheduled_transitions module change `state` to `transition` key from version1.0 to version 1.1
    - more details 
        https://git.drupalcode.org/project/scheduled_transitions/-/blob/8.x-1.0/src/Form/Entity/ScheduledTransitionAddForm.php#L175
        https://git.drupalcode.org/project/scheduled_transitions/-/blob/8.x-1.1/src/Form/Entity/ScheduledTransitionAddForm.php#L199
   so we have to change accordingly 
2. only keep 'publish' and 'archive' options in the `'node_' . $bundle . '_scheduled_transitions_add_form_form'` form.


https://github.com/dpc-sdp/content-vic-gov-au/pull/856