### PR TITLE
[SDPA-4225] updates tide_core to be compatible with Drupal 8.8.6

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         "drupal/config_ignore": "^2.1",
         "drupal/config_split": "^1.4",
         "drupal/config_update": "^1.6",
-        "drupal/core": "8.8.5",
+        "drupal/core": "8.8.6",
         "drupal/diff": "^1.0-RC2",
         "drupal/editor_advanced_link": "^1.4",
         "drupal/entity_browser": "^1.6",
@@ -58,7 +58,7 @@
         "drupal/scheduled_updates": "^1.0-alpha7",
         "drupal/link_field_autocomplete_filter": "^1.8",
         "drupal/queue_mail": "^1.0",
-        "drupal/token": "~1.6.0"
+        "drupal/token": "^1.7"
     },
     "repositories": {
         "drupal": {

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         "drupal/config_ignore": "^2.1",
         "drupal/config_split": "^1.4",
         "drupal/config_update": "^1.6",
-        "drupal/core": "8.7.11",
+        "drupal/core": "8.8.5",
         "drupal/diff": "^1.0-RC2",
         "drupal/editor_advanced_link": "^1.4",
         "drupal/entity_browser": "^1.6",
@@ -70,7 +70,6 @@
         "patches": {
             "drupal/core": {
                 "Contextual links should not be added inside another link - https://www.drupal.org/node/2898875": "https://www.drupal.org/files/issues/2018-03-16/contextual_links_should-2898875-6.patch",
-                "RSS view with fields give wrong URL from path field - https://www.drupal.org/node/2673980#comment-12180229": "https://www.drupal.org/files/issues/rss_view_with_fields-2673980-28.patch",
                 "Custom blocks are no longer displayed and no longer appear in the custom block library - https://www.drupal.org/project/drupal/issues/2997898#comment-12832813": "https://www.drupal.org/files/issues/2018-10-27/2997898-21.patch",
                 "Unrecognised entity operation passed to Menu Link Content throws exceptions - https://www.drupal.org/project/drupal/issues/3016038": "https://www.drupal.org/files/issues/2019-03-03/3016038-menu-link-operation-8.patch",
                 "Make the DateTime input format and descriptive text consistent - https://www.drupal.org/project/drupal/issues/2791693#comment-13024583": "https://www.drupal.org/files/issues/2019-03-16/2791693-38.patch",

--- a/dev-tools.sh
+++ b/dev-tools.sh
@@ -33,6 +33,6 @@
 # stable version.
 #
 # Uncomment and set the Dev-Tools's commit value and commit this change.
-# export GH_COMMIT=COMMIT_SHA
+ export GH_COMMIT=27d302695b50f8edb76c274752617717394e5b0b
 
 bash <(curl -L https://raw.githubusercontent.com/dpc-sdp/dev-tools/master/install?"$(date +%s)") "$@"

--- a/dev-tools.sh
+++ b/dev-tools.sh
@@ -33,6 +33,6 @@
 # stable version.
 #
 # Uncomment and set the Dev-Tools's commit value and commit this change.
- export GH_COMMIT=27d302695b50f8edb76c274752617717394e5b0b
+ export GH_COMMIT=dba4ca3b0f5984376d285d721b8733d4fd792168
 
 bash <(curl -L https://raw.githubusercontent.com/dpc-sdp/dev-tools/master/install?"$(date +%s)") "$@"

--- a/dev-tools.sh
+++ b/dev-tools.sh
@@ -33,6 +33,6 @@
 # stable version.
 #
 # Uncomment and set the Dev-Tools's commit value and commit this change.
- export GH_COMMIT=dba4ca3b0f5984376d285d721b8733d4fd792168
+# export GH_COMMIT=COMMIT_SHA
 
 bash <(curl -L https://raw.githubusercontent.com/dpc-sdp/dev-tools/master/install?"$(date +%s)") "$@"


### PR DESCRIPTION
###Jira
https://digital-engagement.atlassian.net/browse/SDPA-4225
### Changes
1. bumped `drupal/core` to 8.8.6
2. deleted `RSS view with fields give wrong URL from path field`patch

https://github.com/dpc-sdp/dev-tools/pull/36 
https://github.com/dpc-sdp/tide_test/releases/tag/1.2.0
https://github.com/dpc-sdp/content-vic-gov-au/pull/867