### PR TITLE
[SDPA-4186]  restricting jwt editing route.

### DIFF
--- a/src/EventSubscriber/TideCoreRouteAlter.php
+++ b/src/EventSubscriber/TideCoreRouteAlter.php
@@ -26,6 +26,11 @@ class TideCoreRouteAlter extends RouteSubscriberBase {
     if ($route) {
       $route->setDefault('_title', 'Add Scheduled update');
     }
+    // JWT can only be edited by developers who are managing modules.
+    $route = $collection->get('jwt.jwt_config_form');
+    if ($route) {
+      $route->setRequirement('_permission', 'administer modules');
+    }
   }
 
 }


### PR DESCRIPTION
### Jira
https://digital-engagement.atlassian.net/browse/SDPA-4186
### Changes
1. the permissions cannot be changed directly from the permission matrix, as jwt doesn’t have its own permission, it uses system permissions named `Use the administration pages and help`. so we will change it from RouterSubscribe.