### PR TITLE
SDPA-4313 enable schedule transition for each content type

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -104,6 +104,10 @@
             "drupal/permissions_by_term": {
                 "scheduled_transitions module integration issue - https://www.drupal.org/project/permissions_by_term/issues/3065986#comment-13171384": "https://www.drupal.org/files/issues/2019-07-05/permissions_by_term-issue-3065986-D8.6.16.patch"
             },
+            "drupal/password_policy": {
+                "Allow users to bypass validation when editing another user, and correct permission is set - https://www.drupal.org/project/password_policy/issues/2786315": "https://www.drupal.org/files/issues/2019-02-15/edit_other_users-2786315-38.patch",
+                "Add password validation to the user entity as a constraint - https://www.drupal.org/project/password_policy/issues/2941526#comment-13525843": "https://www.drupal.org/files/issues/2020-03-27/password_policy-move-password-validation-to-user-entity-2941526-8-D8.patch"
+            },
             "drupal/scheduled_transitions": {
                 "The revision user is incorrect after CRON ran - https://www.drupal.org/project/scheduled_transitions/issues/3094322": "https://www.drupal.org/files/issues/2019-11-14/3094322_8.x-8.x-1.0-rc3-2.patch"
             },

--- a/config/install/password_policy.password_policy.password_policy_sdpa.yml
+++ b/config/install/password_policy.password_policy.password_policy_sdpa.yml
@@ -36,4 +36,3 @@ roles:
   editor: editor
   previewer: previewer
   event_author: event_author
-  

--- a/config/install/password_policy.password_policy.password_policy_sdpa.yml
+++ b/config/install/password_policy.password_policy.password_policy_sdpa.yml
@@ -1,0 +1,39 @@
+langcode: en
+status: true
+dependencies: {  }
+id: password_policy_sdpa
+label: password_policy_sdpa
+password_reset: 90
+policy_constraints:
+  -
+    id: password_length
+    character_length: 8
+    character_operation: minimum
+  -
+    id: character_types
+    character_types: 4
+  -
+    id: password_policy_character_constraint
+    character_count: 1
+    character_type: uppercase
+  -
+    id: password_policy_character_constraint
+    character_count: 1
+    character_type: lowercase
+  -
+    id: password_policy_character_constraint
+    character_count: 1
+    character_type: numeric
+  -
+    id: password_policy_character_constraint
+    character_count: 1
+    character_type: special
+roles:
+  authenticated: authenticated
+  administrator: administrator
+  approver: approver
+  site_admin: site_admin
+  editor: editor
+  previewer: previewer
+  event_author: event_author
+  

--- a/tide_core.info.yml
+++ b/tide_core.info.yml
@@ -132,6 +132,7 @@ config_devel:
     - paragraphs.paragraphs_type.accordion_content
     - paragraphs.paragraphs_type.links
     - paragraphs.paragraphs_type.related_links
+    - password_policy.password_policy.password_policy_sdpa
     - taxonomy.vocabulary.audience
     - taxonomy.vocabulary.department
     - taxonomy.vocabulary.location

--- a/tide_core.install
+++ b/tide_core.install
@@ -593,9 +593,7 @@ function tide_core_update_8021() {
  */
 function tide_core_update_8022() {
   // Get the available content types.
-  $types = \Drupal::entityTypeManager()
-  ->getStorage('node_type')
-  ->loadMultiple();
+  $types = \Drupal::entityTypeManager()->getStorage('node_type')->loadMultiple();
   foreach ($types as $type) {
     if ($type->id()) {
       $content_types[] = $type->id();

--- a/tide_core.install
+++ b/tide_core.install
@@ -587,3 +587,49 @@ function tide_core_update_8021() {
   $config_storage = \Drupal::service('config.storage');
   $config_storage->write($view, $source->read($view));
 }
+
+/**
+ * Enable scheduled transitions for each content type.
+ */
+function tide_core_update_8022() {
+  // Get the available content types.
+  $types = \Drupal::entityTypeManager()
+  ->getStorage('node_type')
+  ->loadMultiple();
+  foreach ($types as $type) {
+    if ($type->id()) {
+      $content_types[] = $type->id();
+    }
+  }
+  if (\Drupal::moduleHandler()->moduleExists('scheduled_transitions') && !empty($content_types)) {
+    $config_factory = \Drupal::configFactory();
+    $config = $config_factory->getEditable('scheduled_transitions.settings');
+    $bundles = $config->get('bundles');
+    if (!$bundles) {
+      foreach ($content_types as $bundle) {
+        $bundles_array[] = ['entity_type' => 'node', 'bundle' => $bundle];
+      }
+      $config->set('bundles', $bundles_array);
+      $config->save();
+    }
+  }
+}
+
+/**
+ * Import sdpa password policy.
+ */
+function tide_core_update_8023() {
+  if (\Drupal::moduleHandler()->moduleExists('password_policy')) {
+    // Remove default password policy if exists.
+    $config_factory = \Drupal::configFactory();
+    $config = $config_factory->getEditable('password_policy.password_policy.default');
+    $default_id = $config->get('id');
+    if (empty($default_id)) {
+      $config->delete();
+    }
+    // Import the sdpa password policy.
+    module_load_include('inc', 'tide_core', 'includes/helpers');
+    $config_location = [drupal_get_path('module', 'tide_core') . '/config/install'];
+    _tide_import_single_config('password_policy.password_policy.password_policy_sdpa', $config_location);
+  }
+}


### PR DESCRIPTION
### Jira
https://digital-engagement.atlassian.net/browse/SDPA-4313
### Changes
1. Added update hook to enable schedule transitions for each content type.
2. Added update hook to remove default password policy, if exists, and replace it with the SDPA password policy.
3. Added patches for the password policy module.