### PR TITLE
[SW-132] add scheule publishing drush 8 wrapper

### DIFF
--- a/tide_core.drush.inc
+++ b/tide_core.drush.inc
@@ -1,0 +1,37 @@
+<?php
+
+/**
+ * @file
+ * Drush integration for the tide_core module.
+ */
+
+/**
+ * Implements hook_drush_help().
+ */
+function tide_core_drush_help($section) {
+  switch ($section) {
+    case 'tide-core-scheduled-transitions-queue-jobs':
+      return dt('Drush 8 wrapper for the Drush 9 Scheduled transitions queuing Drush command.');
+      break;
+  }
+}
+
+/**
+ * Implements hook_drush_command().
+ */
+function tide_core_drush_command() {
+  $commands['tide-core-scheduled-transitions-queue-jobs'] = [
+    'description' => dt('Drush 8 wrapper for the Drush 9 Scheduled transitions queuing Drush command.'),
+  ];
+
+  return $commands;
+}
+
+/**
+ * Dispatches scheduled media releases.
+ */
+function drush_tide_core_tide_core_scheduled_transitions_queue_jobs() {
+  $jobs = \Drupal::service('scheduled_transitions.jobs');
+  $jobs->jobCreator();
+  drush_print(dt('Scheduled transitions queued.'));
+}

--- a/tide_core.drush.inc
+++ b/tide_core.drush.inc
@@ -12,7 +12,6 @@ function tide_core_drush_help($section) {
   switch ($section) {
     case 'tide-core-scheduled-transitions-queue-jobs':
       return dt('Drush 8 wrapper for the Drush 9 Scheduled transitions queuing Drush command.');
-      break;
   }
 }
 


### PR DESCRIPTION
### Jira
https://digital-engagement.atlassian.net/browse/SW-132
### Changes
relates to https://github.com/dpc-sdp/content-premier-vic-gov-au/pull/75
> In this PR, https://github.com/dpc-sdp/content-premier-vic-gov-au/pull/75, I've added a Drush 8 wrapper around the Drush 9 command provided by the Scheduled Transitions module. We need to add this to tide_core so we can use this until we move to Drush 9 in the cli container.