### PR TITLE
[SDPA-4271] Changes the order of transitions list.

### DIFF
--- a/tide_core.install
+++ b/tide_core.install
@@ -587,3 +587,34 @@ function tide_core_update_8021() {
   $config_storage = \Drupal::service('config.storage');
   $config_storage->write($view, $source->read($view));
 }
+
+/**
+ * Changes the order of transitions list.
+ */
+function tide_core_update_8022() {
+  $order = [
+    'Create New Draft',
+    'Needs Review',
+    'Send back to Draft',
+    'Publish',
+    'Archive pending',
+    'Archive',
+    'Restore to Draft',
+    'Published',
+  ];
+  $editorial_workflow = Workflow::load('editorial');
+  $type_settings = $editorial_workflow->get('type_settings');
+  if (isset($type_settings['transitions']) && !empty($type_settings['transitions'])) {
+    $keys = array_flip($order);
+    foreach ($keys as $label => $key) {
+      foreach ($type_settings['transitions'] as &$transition) {
+        if ($label == $transition['label']) {
+          $transition['weight'] = $key;
+          continue;
+        }
+      }
+    }
+    $editorial_workflow->set('type_settings', $type_settings);
+    $editorial_workflow->save();
+  }
+}


### PR DESCRIPTION
### Jira
https://digital-engagement.atlassian.net/browse/SDPA-4271

### Issue
1. the original requirement is to re-order transitions list based on user roles.
    1. it could be achieved , but with ugly custom code in form_alter.
    2. we might not want to increase its logical complexity 
    3. after discussed with Vanessa. we will apply this change to all users.

### Change
1. Changes the order of transitions list by change its `weight`.  drupal way 😉 