### PR TITLE
[SDPA-4378] username enumeration prevention

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
         "drupal/entity_reference_revisions": "~1.6.0",
         "drupal/entity_embed": "^1.0.0-beta2",
         "drupal/environment_indicator": "^3.5",
-        "drupal/events_log_track": "^2.0",
+        "drupal/events_log_track": "^1.1",
         "drupal/fakeobjects": "^1.0",
         "drupal/fast_404": "^1.0-alpha4",
         "drupal/field_group": "3.0.0-rc1",
@@ -90,6 +90,14 @@
             "drupal/token": {
                 "Node preview button generates useless menu link - https://www.drupal.org/node/2823731#comment-11905884": "https://www.drupal.org/files/issues/token_node_preview_menu_link-2823731-4.patch",
                 "Summary token not fully handled in fields": "https://www.drupal.org/files/issues/tokens.body-with-summary.patch"
+            },
+            "drupal/events_log_track": {
+                "Events Log Track breaks Entity Browser #5 - https://www.drupal.org/project/events_log_track/issues/2934036": "https://www.drupal.org/files/issues/2018-04-19/2934036-check_empty_submit-5.patch",
+                "Entities with title longer than 50 characters - https://www.drupal.org/project/events_log_track/issues/2930817": "https://www.drupal.org/files/issues/increase-character-length-2930817-2.patch",
+                "Event logs for change in workflows - https://www.drupal.org/project/events_log_track/issues/2974170": "https://www.drupal.org/files/issues/2018-06-26/events_log_track-add-workflows-2974170-7.patch",
+                "Add handlers for file and media entities - https://www.drupal.org/project/events_log_track/issues/2959769": "https://www.drupal.org/files/issues/2018-06-26/events-log-track_add-file-media-2959769-9.patch",
+                "Skip password logging during failed authentication attempt - https://www.drupal.org/project/events_log_track/issues/3027463": "https://www.drupal.org/files/issues/2019-01-22/event-log-track-auth-3027463-2.patch",
+                "Fix fatal error when we request password with non-existing users/emails on the Events Log Track User Authentication - https://www.drupal.org/node/3060838": "https://www.drupal.org/files/issues/2019-06-11/3060838-4.patch"
             },
             "drupal/field_group": {
                 "Do not translate field group labels using interface translation. - https://www.drupal.org/project/field_group/issues/2846617": "https://www.drupal.org/files/issues/2019-04-18/field_group-use_config_translation-2846617-26.patch"

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
         "drupal/entity_reference_revisions": "~1.6.0",
         "drupal/entity_embed": "^1.0.0-beta2",
         "drupal/environment_indicator": "^3.5",
-        "drupal/events_log_track": "^1.1",
+        "drupal/events_log_track": "^2.0",
         "drupal/fakeobjects": "^1.0",
         "drupal/fast_404": "^1.0-alpha4",
         "drupal/field_group": "3.0.0-rc1",
@@ -59,7 +59,8 @@
         "drupal/scheduled_updates": "^1.0-alpha7",
         "drupal/link_field_autocomplete_filter": "^1.8",
         "drupal/queue_mail": "^1.0",
-        "drupal/token": "^1.7"
+        "drupal/token": "^1.7",
+        "drupal/username_enumeration_prevention": "^1.1"
     },
     "repositories": {
         "drupal": {
@@ -89,13 +90,6 @@
             "drupal/token": {
                 "Node preview button generates useless menu link - https://www.drupal.org/node/2823731#comment-11905884": "https://www.drupal.org/files/issues/token_node_preview_menu_link-2823731-4.patch",
                 "Summary token not fully handled in fields": "https://www.drupal.org/files/issues/tokens.body-with-summary.patch"
-            },
-            "drupal/events_log_track": {
-                "Events Log Track breaks Entity Browser #5 - https://www.drupal.org/project/events_log_track/issues/2934036": "https://www.drupal.org/files/issues/2018-04-19/2934036-check_empty_submit-5.patch",
-                "Entities with title longer than 50 characters - https://www.drupal.org/project/events_log_track/issues/2930817": "https://www.drupal.org/files/issues/increase-character-length-2930817-2.patch",
-                "Event logs for change in workflows - https://www.drupal.org/project/events_log_track/issues/2974170": "https://www.drupal.org/files/issues/2018-06-26/events_log_track-add-workflows-2974170-7.patch",
-                "Add handlers for file and media entities - https://www.drupal.org/project/events_log_track/issues/2959769": "https://www.drupal.org/files/issues/2018-06-26/events-log-track_add-file-media-2959769-9.patch",
-                "Skip password logging during failed authentication attempt - https://www.drupal.org/project/events_log_track/issues/3027463": "https://www.drupal.org/files/issues/2019-01-22/event-log-track-auth-3027463-2.patch"
             },
             "drupal/field_group": {
                 "Do not translate field group labels using interface translation. - https://www.drupal.org/project/field_group/issues/2846617": "https://www.drupal.org/files/issues/2019-04-18/field_group-use_config_translation-2846617-26.patch"

--- a/tests/behat/features/access.feature
+++ b/tests/behat/features/access.feature
@@ -44,3 +44,11 @@ Feature: Access permissions
     And I select "Remove the Previewer role from the selected user(s)" from "edit-action"
     And I select "Remove the Editor role from the selected user(s)" from "edit-action"
     And I select "Remove the Approver role from the selected user(s)" from "edit-action"
+
+  @api @javascript
+  Scenario: Password reset should not show username validation message.
+    Given I go to "user/password"
+    Then I fill in "Username or email address" with "test@example.com"
+    And I press "Submit"
+    And I should see the success message "If the username or email address exists and is active, further instructions have been sent to your email address."
+    And I save screenshot

--- a/tide_core.install
+++ b/tide_core.install
@@ -684,3 +684,13 @@ function tide_core_update_8026() {
   $config->set('display.default.display_options.empty.area.content.format', 'plain_text');
   $config->save();
 }
+
+/**
+ * Enable username_enumeration_prevention module.
+ */
+function tide_core_update_8027() {
+  if (!\Drupal::moduleHandler()->moduleExists('username_enumeration_prevention')) {
+    $module_installer = \Drupal::service('module_installer');
+    $module_installer->install(['username_enumeration_prevention']);
+  }
+}


### PR DESCRIPTION
### Jira
https://digital-engagement.atlassian.net/browse/SDPA-4378

### Issue 
If I enter an invalid username on the login or forgot password pages, the error message indicates if that username is valid.

### Changes
1. Added username_enumeration_prevention module and update hook to enable it.
2. Added behat test to check the error message doesn't indicate whether the email address is valid or not.
3. Added patch for events_log_track module.

### Testing Pr
https://github.com/dpc-sdp/content-vic-gov-au/pull/904 ([Test Link](https://nginx-php-content-vic-pr-904.lagoon.vicsdp.amazee.io/))

### Screenshot
<img width="1402" alt="Screen Shot 2020-07-17 at 9 27 23 am" src="https://user-images.githubusercontent.com/20810541/87732253-d0b7ea00-c80f-11ea-8097-52627c602240.png">