### PR TITLE
clean up drush 8 command

### DIFF
--- a/tide_core.drush.inc
+++ b/tide_core.drush.inc
@@ -29,7 +29,7 @@ function tide_core_drush_command() {
 /**
  * Dispatches scheduled media releases.
  */
-function drush_tide_core_tide_core_scheduled_transitions_queue_jobs() {
+function drush_tide_core_scheduled_transitions_queue_jobs() {
   $jobs = \Drupal::service('scheduled_transitions.jobs');
   $jobs->jobCreator();
   drush_print(dt('Scheduled transitions queued.'));


### PR DESCRIPTION
### Changes
1. the drush function name should be named as `drush_tide_core_scheduled_transitions_queue_jobs`