### PR TITLE
Fixes publish action bug

### DIFF
--- a/src/Form/NodeActionForm.php
+++ b/src/Form/NodeActionForm.php
@@ -194,8 +194,9 @@ class NodeActionForm extends ConfirmFormBase {
     }
 
     foreach ($entities as $entity) {
+      $vid = $controller->getLatestRevisionId($entity->id());
+      $entity = $controller->loadRevision($vid);
       $entity->set('moderation_state', $to_state);
-      $entity->setPublished($action == 'publish');
       $entity->save();
     }
   }


### PR DESCRIPTION
### Changes

1. the original logic is not that right. 
The correct way:
When we `publish` a node, we are changing the latest revision to `published` state. 