### PR TITLE
[tide_oauth_changes] Updated drush command to generate keys if no envkeys.

### DIFF
--- a/modules/tide_oauth/README.md
+++ b/modules/tide_oauth/README.md
@@ -23,7 +23,7 @@
        post-rollout:
           - run:
              name: Generate OAuth keys from ENV variables.
-             command: 'drush tide-oauth:env-keygen'
+             command: 'drush tide-oauth:keygen'
              service: cli
     ```    
 

--- a/modules/tide_oauth/drush/tide_oauth.drush.inc
+++ b/modules/tide_oauth/drush/tide_oauth.drush.inc
@@ -24,23 +24,11 @@ function drush_tide_oauth_keygen() {
   /** @var \Drupal\tide_oauth\EnvKeyGenerator $env_key_generator */
   $env_key_generator = \Drupal::service('tide_oauth.env_key_generator');
   // Generate the OAuth encryption keys from Environment variables.
-  if ($env_key_generator->hasEnvKeys()) {
-    if ($env_key_generator->generateEnvKeys()) {
-      // Update Simple OAuth settings.
-      $env_key_generator->setSimpleOauthKeySettings();
-    }
-    else {
-      drush_set_error('Could not generate OAuth keys from TIDE_OAUTH_*_KEY environment variables.');
-    }
+  if ($env_key_generator->generateEnvKeys()) {
+    // Update Simple OAuth settings.
+    $env_key_generator->setSimpleOauthKeySettings();
   }
   else {
-    // Generate keys if Environment variables are not set.
-    if ($env_key_generator->generateOauthKeys()) {
-      // Update Simple OAuth settings.
-      $env_key_generator->setSimpleOauthKeySettings();
-    }
-    else {
-      drush_set_error('Could not generate keys.');
-    }
+    drush_set_error('Could not generate OAuth keys from TIDE_OAUTH_*_KEY environment variables.');
   }
 }

--- a/modules/tide_oauth/drush/tide_oauth.drush.inc
+++ b/modules/tide_oauth/drush/tide_oauth.drush.inc
@@ -11,16 +11,16 @@ use Drupal\tide_oauth\EnvKeyGenerator;
  * Implements hook_drush_command().
  */
 function tide_oauth_drush_command() {
-  $commands['tide-oauth-env-keygen'] = [
+  $commands['tide-oauth-keygen'] = [
     'description' => 'Generate OAuth keys from environment variables',
     'drupal dependencies' => ['tide_oauth'],
-    'aliases' => ['toenvkg', 'tide-oauth:env-keygen'],
+    'aliases' => ['tokgn', 'tide-oauth:keygen'],
   ];
   return $commands;
 }
 
 /**
- * Callback for tide-oauth:env-keygen command.
+ * Callback for tide-oauth:keygen command.
  */
 function drush_tide_oauth_keygen() {
   /** @var \Drupal\tide_oauth\EnvKeyGenerator $env_key_generator */

--- a/modules/tide_oauth/drush/tide_oauth.drush.inc
+++ b/modules/tide_oauth/drush/tide_oauth.drush.inc
@@ -5,8 +5,6 @@
  * Tide OAuth Drush commands.
  */
 
-use Drupal\tide_oauth\EnvKeyGenerator;
-
 /**
  * Implements hook_drush_command().
  */
@@ -25,8 +23,6 @@ function tide_oauth_drush_command() {
 function drush_tide_oauth_keygen() {
   /** @var \Drupal\tide_oauth\EnvKeyGenerator $env_key_generator */
   $env_key_generator = \Drupal::service('tide_oauth.env_key_generator');
-  /** @var \Drupal\Core\File\FileSystemInterface $fs */
-  $fs = \Drupal::service('file_system');
   // Generate the OAuth encryption keys from Environment variables.
   if ($env_key_generator->hasEnvKeys()) {
     if ($env_key_generator->generateEnvKeys()) {
@@ -38,14 +34,13 @@ function drush_tide_oauth_keygen() {
     }
   }
   else {
-    /** @var \Drupal\simple_oauth\Service\KeyGeneratorService $key_generator */
-    $key_generator = \Drupal::service('simple_oauth.key.generator');
-    $key_generator->generateKeys('private://');
-    $fs->move('private://private.key', EnvKeyGenerator::FILE_PRIVATE_KEY);
-    $fs->chmod(EnvKeyGenerator::FILE_PRIVATE_KEY, 0600);
-    $fs->move('private://public.key', EnvKeyGenerator::FILE_PUBLIC_KEY);
-    $fs->chmod(EnvKeyGenerator::FILE_PUBLIC_KEY, 0600);
-    // Update Simple OAuth settings.
-    $env_key_generator->setSimpleOauthKeySettings();
+    // Generate keys if Environment variables are not set.
+    if ($env_key_generator->generateOauthKeys()) {
+      // Update Simple OAuth settings.
+      $env_key_generator->setSimpleOauthKeySettings();
+    }
+    else {
+      drush_set_error('Could not generate keys.');
+    }
   }
 }

--- a/modules/tide_oauth/drush/tide_oauth.drush.inc
+++ b/modules/tide_oauth/drush/tide_oauth.drush.inc
@@ -29,6 +29,6 @@ function drush_tide_oauth_keygen() {
     $env_key_generator->setSimpleOauthKeySettings();
   }
   else {
-    drush_set_error('Could not generate OAuth keys from TIDE_OAUTH_*_KEY environment variables.');
+    drush_set_error('Could not generate OAuth keys.');
   }
 }

--- a/modules/tide_oauth/drush/tide_oauth.drush.inc
+++ b/modules/tide_oauth/drush/tide_oauth.drush.inc
@@ -5,6 +5,8 @@
  * Tide OAuth Drush commands.
  */
 
+use Drupal\tide_oauth\EnvKeyGenerator;
+
 /**
  * Implements hook_drush_command().
  */
@@ -23,6 +25,8 @@ function tide_oauth_drush_command() {
 function drush_tide_oauth_env_keygen() {
   /** @var \Drupal\tide_oauth\EnvKeyGenerator $env_key_generator */
   $env_key_generator = \Drupal::service('tide_oauth.env_key_generator');
+  /** @var \Drupal\Core\File\FileSystemInterface $fs */
+  $fs = \Drupal::service('file_system');
   // Generate the OAuth encryption keys from Environment variables.
   if ($env_key_generator->hasEnvKeys()) {
     if ($env_key_generator->generateEnvKeys()) {
@@ -32,5 +36,16 @@ function drush_tide_oauth_env_keygen() {
     else {
       drush_set_error('Could not generate OAuth keys from TIDE_OAUTH_*_KEY environment variables.');
     }
+  }
+  else {
+    /** @var \Drupal\simple_oauth\Service\KeyGeneratorService $key_generator */
+    $key_generator = \Drupal::service('simple_oauth.key.generator');
+    $key_generator->generateKeys('private://');
+    $fs->move('private://private.key', EnvKeyGenerator::FILE_PRIVATE_KEY);
+    $fs->chmod(EnvKeyGenerator::FILE_PRIVATE_KEY, 0600);
+    $fs->move('private://public.key', EnvKeyGenerator::FILE_PUBLIC_KEY);
+    $fs->chmod(EnvKeyGenerator::FILE_PUBLIC_KEY, 0600);
+    // Update Simple OAuth settings.
+    $env_key_generator->setSimpleOauthKeySettings();
   }
 }

--- a/modules/tide_oauth/drush/tide_oauth.drush.inc
+++ b/modules/tide_oauth/drush/tide_oauth.drush.inc
@@ -22,7 +22,7 @@ function tide_oauth_drush_command() {
 /**
  * Callback for tide-oauth:env-keygen command.
  */
-function drush_tide_oauth_env_keygen() {
+function drush_tide_oauth_keygen() {
   /** @var \Drupal\tide_oauth\EnvKeyGenerator $env_key_generator */
   $env_key_generator = \Drupal::service('tide_oauth.env_key_generator');
   /** @var \Drupal\Core\File\FileSystemInterface $fs */

--- a/modules/tide_oauth/src/Commands/TideOauthCommands.php
+++ b/modules/tide_oauth/src/Commands/TideOauthCommands.php
@@ -3,6 +3,8 @@
 namespace Drupal\tide_oauth\Commands;
 
 use Drupal\tide_oauth\EnvKeyGenerator;
+use Drupal\Core\File\FileSystemInterface;
+use Drupal\simple_oauth\Service\KeyGeneratorService;
 use Drush\Commands\DrushCommands;
 
 /**
@@ -20,14 +22,34 @@ class TideOauthCommands extends DrushCommands {
   protected $envKeyGenerator;
 
   /**
+   * File System.
+   *
+   * @var \Drupal\Core\File\FileSystemInterface
+   */
+  protected $fileSystem;
+
+  /**
+   * Simple Oauth Key Generator Service.
+   *
+   * @var \Drupal\simple_oauth\Service\KeyGeneratorService
+   */
+  protected $keyGenerator;
+
+  /**
    * TideOauthCommands constructor.
    *
    * @param \Drupal\tide_oauth\EnvKeyGenerator $env_key_generator
    *   Env Key Generator.
+   * @param \Drupal\Core\File\FileSystemInterface $file_system
+   *   File system.
+   * @param \Drupal\simple_oauth\Service\KeyGeneratorService $key_generator
+   *   Simple Oauth Key Generator Service.
    */
-  public function __construct(EnvKeyGenerator $env_key_generator) {
+  public function __construct(EnvKeyGenerator $env_key_generator, FileSystemInterface $file_system, KeyGeneratorService $key_generator) {
     parent::__construct();
     $this->envKeyGenerator = $env_key_generator;
+    $this->fileSystem = $file_system;
+    $this->$keyGenerator = $key_generator;
   }
 
   /**
@@ -50,6 +72,16 @@ class TideOauthCommands extends DrushCommands {
       else {
         $this->io()->error('Could not generate OAuth keys from TIDE_OAUTH_*_KEY environment variables.');
       }
+    }
+    else {
+      $this->$keyGenerator->generateKeys('private://');
+      $this->fileSystem->move('private://private.key', EnvKeyGenerator::FILE_PRIVATE_KEY);
+      $this->fileSystem->chmod(EnvKeyGenerator::FILE_PRIVATE_KEY, 0600);
+      $this->fileSystem->move('private://public.key', EnvKeyGenerator::FILE_PUBLIC_KEY);
+      $this->fileSystem->chmod(EnvKeyGenerator::FILE_PUBLIC_KEY, 0600);
+      // Update Simple OAuth settings.
+      $this->envKeyGenerator->setSimpleOauthKeySettings();
+      $this->io()->success('OAuth keys have been created.');
     }
   }
 

--- a/modules/tide_oauth/src/Commands/TideOauthCommands.php
+++ b/modules/tide_oauth/src/Commands/TideOauthCommands.php
@@ -24,8 +24,6 @@ class TideOauthCommands extends DrushCommands {
    *
    * @param \Drupal\tide_oauth\EnvKeyGenerator $env_key_generator
    *   Env Key Generator.
-   * @param \Drupal\Core\File\FileSystemInterface $file_system
-   *   File system.
    */
   public function __construct(EnvKeyGenerator $env_key_generator) {
     parent::__construct();

--- a/modules/tide_oauth/src/Commands/TideOauthCommands.php
+++ b/modules/tide_oauth/src/Commands/TideOauthCommands.php
@@ -55,12 +55,12 @@ class TideOauthCommands extends DrushCommands {
   /**
    * Generate OAuth keys from Environment variables.
    *
-   * @usage drush tide-oauth:env-keygen
+   * @usage drush tide-oauth:keygen
    *   Generate OAuth keys from Environment variables.
    *
-   * @command tide-oauth:env-keygen
+   * @command tide-oauth:keygen
    * @validate-module-enabled tide_oauth
-   * @aliases toenvkg,tide-oauth-env-keygen
+   * @aliases tokgn,tide-oauth-keygen
    */
   public function generateKeys() {
     if ($this->envKeyGenerator->hasEnvKeys()) {

--- a/modules/tide_oauth/src/Commands/TideOauthCommands.php
+++ b/modules/tide_oauth/src/Commands/TideOauthCommands.php
@@ -41,26 +41,13 @@ class TideOauthCommands extends DrushCommands {
    * @aliases tokgn,tide-oauth-keygen
    */
   public function generateKeys() {
-    if ($this->envKeyGenerator->hasEnvKeys()) {
-      if ($this->envKeyGenerator->generateEnvKeys()) {
-        // Update Simple OAuth settings.
-        $this->envKeyGenerator->setSimpleOauthKeySettings();
-        $this->io()->success('OAuth keys have been created from TIDE_OAUTH_*_KEY environment variables.');
-      }
-      else {
-        $this->io()->error('Could not generate OAuth keys from TIDE_OAUTH_*_KEY environment variables.');
-      }
+    if ($this->envKeyGenerator->generateEnvKeys()) {
+      // Update Simple OAuth settings.
+      $this->envKeyGenerator->setSimpleOauthKeySettings();
+      $this->io()->success('OAuth keys have been created from TIDE_OAUTH_*_KEY environment variables.');
     }
     else {
-      // Generate keys if Environment variables are not set.
-      if ($this->envKeyGenerator->generateOauthKeys()) {
-        // Update Simple OAuth settings.
-        $this->envKeyGenerator->setSimpleOauthKeySettings();
-        $this->io()->success('OAuth keys have been created.');
-      }
-      else {
-        $this->io()->error('Could not generate OAuth keys.');
-      }
+      $this->io()->error('Could not generate OAuth keys from TIDE_OAUTH_*_KEY environment variables.');
     }
   }
 

--- a/modules/tide_oauth/src/Commands/TideOauthCommands.php
+++ b/modules/tide_oauth/src/Commands/TideOauthCommands.php
@@ -44,10 +44,10 @@ class TideOauthCommands extends DrushCommands {
     if ($this->envKeyGenerator->generateEnvKeys()) {
       // Update Simple OAuth settings.
       $this->envKeyGenerator->setSimpleOauthKeySettings();
-      $this->io()->success('OAuth keys have been created from TIDE_OAUTH_*_KEY environment variables.');
+      $this->io()->success('OAuth keys have been created.');
     }
     else {
-      $this->io()->error('Could not generate OAuth keys from TIDE_OAUTH_*_KEY environment variables.');
+      $this->io()->error('Could not generate OAuth keys.');
     }
   }
 

--- a/modules/tide_oauth/src/Commands/TideOauthCommands.php
+++ b/modules/tide_oauth/src/Commands/TideOauthCommands.php
@@ -3,8 +3,6 @@
 namespace Drupal\tide_oauth\Commands;
 
 use Drupal\tide_oauth\EnvKeyGenerator;
-use Drupal\Core\File\FileSystemInterface;
-use Drupal\simple_oauth\Service\KeyGeneratorService;
 use Drush\Commands\DrushCommands;
 
 /**
@@ -29,27 +27,17 @@ class TideOauthCommands extends DrushCommands {
   protected $fileSystem;
 
   /**
-   * Simple Oauth Key Generator Service.
-   *
-   * @var \Drupal\simple_oauth\Service\KeyGeneratorService
-   */
-  protected $keyGenerator;
-
-  /**
    * TideOauthCommands constructor.
    *
    * @param \Drupal\tide_oauth\EnvKeyGenerator $env_key_generator
    *   Env Key Generator.
    * @param \Drupal\Core\File\FileSystemInterface $file_system
    *   File system.
-   * @param \Drupal\simple_oauth\Service\KeyGeneratorService $key_generator
-   *   Simple Oauth Key Generator Service.
    */
-  public function __construct(EnvKeyGenerator $env_key_generator, FileSystemInterface $file_system, KeyGeneratorService $key_generator) {
+  public function __construct(EnvKeyGenerator $env_key_generator, FileSystemInterface $file_system) {
     parent::__construct();
     $this->envKeyGenerator = $env_key_generator;
     $this->fileSystem = $file_system;
-    $this->$keyGenerator = $key_generator;
   }
 
   /**
@@ -74,14 +62,15 @@ class TideOauthCommands extends DrushCommands {
       }
     }
     else {
-      $this->$keyGenerator->generateKeys('private://');
-      $this->fileSystem->move('private://private.key', EnvKeyGenerator::FILE_PRIVATE_KEY);
-      $this->fileSystem->chmod(EnvKeyGenerator::FILE_PRIVATE_KEY, 0600);
-      $this->fileSystem->move('private://public.key', EnvKeyGenerator::FILE_PUBLIC_KEY);
-      $this->fileSystem->chmod(EnvKeyGenerator::FILE_PUBLIC_KEY, 0600);
-      // Update Simple OAuth settings.
-      $this->envKeyGenerator->setSimpleOauthKeySettings();
-      $this->io()->success('OAuth keys have been created.');
+      // Generate keys if Environment variables are not set.
+      if ($this->envKeyGenerator->generateOauthKeys()) {
+        // Update Simple OAuth settings.
+        $this->envKeyGenerator->setSimpleOauthKeySettings();
+        $this->io()->success('OAuth keys have been created.');
+      }
+      else {
+        $this->io()->error('Could not generate OAuth keys.');
+      }
     }
   }
 

--- a/modules/tide_oauth/src/Commands/TideOauthCommands.php
+++ b/modules/tide_oauth/src/Commands/TideOauthCommands.php
@@ -20,13 +20,6 @@ class TideOauthCommands extends DrushCommands {
   protected $envKeyGenerator;
 
   /**
-   * File System.
-   *
-   * @var \Drupal\Core\File\FileSystemInterface
-   */
-  protected $fileSystem;
-
-  /**
    * TideOauthCommands constructor.
    *
    * @param \Drupal\tide_oauth\EnvKeyGenerator $env_key_generator
@@ -34,10 +27,9 @@ class TideOauthCommands extends DrushCommands {
    * @param \Drupal\Core\File\FileSystemInterface $file_system
    *   File system.
    */
-  public function __construct(EnvKeyGenerator $env_key_generator, FileSystemInterface $file_system) {
+  public function __construct(EnvKeyGenerator $env_key_generator) {
     parent::__construct();
     $this->envKeyGenerator = $env_key_generator;
-    $this->fileSystem = $file_system;
   }
 
   /**

--- a/modules/tide_oauth/src/EnvKeyGenerator.php
+++ b/modules/tide_oauth/src/EnvKeyGenerator.php
@@ -100,7 +100,7 @@ class EnvKeyGenerator {
    */
   public function generateEnvKeys() : bool {
     if (!$this->hasEnvKeys()) {
-      $this->generateOauthKeys();
+      return $this->generateOauthKeys();
     }
 
     $private = 'private://';

--- a/modules/tide_oauth/src/EnvKeyGenerator.php
+++ b/modules/tide_oauth/src/EnvKeyGenerator.php
@@ -77,7 +77,7 @@ class EnvKeyGenerator {
     $this->fileSystem = $file_system;
     $this->fileSystemChecker = $fs_checker;
     $this->configFactory = $config_factory;
-    $this->$keyGenerator = $key_generator;
+    $this->keyGenerator = $key_generator;
     $this->privateKey = getenv(static::ENV_PRIVATE_KEY);
     $this->publicKey = getenv(static::ENV_PUBLIC_KEY);
   }
@@ -100,7 +100,7 @@ class EnvKeyGenerator {
    */
   public function generateEnvKeys() : bool {
     if (!$this->hasEnvKeys()) {
-      return FALSE;
+      $this->generateOauthKeys();
     }
 
     $private = 'private://';
@@ -165,7 +165,7 @@ class EnvKeyGenerator {
       return FALSE;
     }
 
-    $this->$keyGenerator->generateKeys('private://');
+    $this->keyGenerator->generateKeys('private://');
     $this->fileSystem->move('private://private.key', static::FILE_PRIVATE_KEY);
     $this->fileSystem->chmod(static::FILE_PRIVATE_KEY, 0600);
     $this->fileSystem->move('private://public.key', static::FILE_PUBLIC_KEY);

--- a/modules/tide_oauth/tide_oauth.services.yml
+++ b/modules/tide_oauth/tide_oauth.services.yml
@@ -18,3 +18,4 @@ services:
       - '@file_system'
       - '@simple_oauth.filesystem_checker'
       - '@config.factory'
+      - '@simple_oauth.key.generator'


### PR DESCRIPTION
### Changes based on the following command
```
The post-rollout task runs the Drush command to generate the key pair from the env variables, but it doesn't generate a new key pair if the env variables are not set. We could modify that command to do:

check if there is a valid key pair in private://
if not, try to create a key pair from env variables
if the env variables are not set, generate a new key pair.
```