### PR TITLE
[SDPA-4885] Fixes moderation_state layout issue in the clone form

### DIFF
--- a/tide_core.module
+++ b/tide_core.module
@@ -102,6 +102,11 @@ function tide_core_form_alter(&$form, FormStateInterface $form_state, $form_id) 
         }
       }
     }
+    if ($form_id == 'node_' . $bundle . '_quick_node_clone_form') {
+      if (isset($form['moderation_state'])) {
+        $form['moderation_state']['#group'] = 'footer';
+      }
+    }
   }
 }
 


### PR DESCRIPTION
### Jira
https://digital-engagement.atlassian.net/browse/SDPA-4885

### Changes
1. grouping `moderation state` into `footer` region.

---

### After the change
![image](https://user-images.githubusercontent.com/8788145/101858838-85d3b000-3bbe-11eb-98c8-2086a844f1e5.png)
