### PR TITLE
[client_id_issue] Added fix for tide_oauth client id issue.

### DIFF
--- a/modules/tide_oauth/tide_oauth.install
+++ b/modules/tide_oauth/tide_oauth.install
@@ -64,10 +64,10 @@ function _tide_oauth_update_consumer_long_description_field() {
     ]);
     $uuid = _tide_retrieve_config_uuid('field.field.consumer.consumer.' . $field_name);
     if ($uuid) {
-      $field_config->setOriginalId($field_config->id());
       $field_config->set('uuid', $uuid);
-      $field_config->save();
     }
+    $field_config->setOriginalId($field_config->id());
+    $field_config->save();
   }
 
   // Update form display and view display.
@@ -184,10 +184,10 @@ function _tide_oauth_update_consumer_machine_name_field() {
     ]);
     $uuid = _tide_retrieve_config_uuid('field.field.consumer.consumer.' . $field_name);
     if ($uuid) {
-      $field_config->setOriginalId($field_config->id());
       $field_config->set('uuid', $uuid);
-      $field_config->save();
     }
+    $field_config->setOriginalId($field_config->id());
+    $field_config->save();
   }
 
   // Update form display and view display.


### PR DESCRIPTION
### Issue
The **__tide_retrieve_config_uuid_** function wasn't retrieving the UUID for the config at first install, as it couldn't find the config in config/sync. So when it tries to create and save the new field, it couldn't save because it was not entering the UUID check if condition as there wasn't any uuid.

### Change
Took out the field id and field save call out of UUID if condition, so the new fields get created and saved at the fiirst install.