### PR TITLE
[SDPSUP-2516] Added code to prepare the private directory before generating oauth keys.

### DIFF
--- a/modules/tide_oauth/src/EnvKeyGenerator.php
+++ b/modules/tide_oauth/src/EnvKeyGenerator.php
@@ -165,6 +165,9 @@ class EnvKeyGenerator {
       return FALSE;
     }
 
+    $private = 'private://';
+    $this->fileSystem->prepareDirectory($private, FileSystemInterface::CREATE_DIRECTORY);
+
     $this->keyGenerator->generateKeys('private://');
     $this->fileSystem->move('private://private.key', static::FILE_PRIVATE_KEY);
     $this->fileSystem->chmod(static::FILE_PRIVATE_KEY, 0600);


### PR DESCRIPTION
### Jira
https://digital-engagement.atlassian.net/browse/SDPSUP-2516

### Issue
During openshift build, the post-rollout tasks run the drush command to generate the oauth keys [here](https://github.com/dpc-sdp/content-vic-gov-au/blob/develop/.lagoon.yml#L41)
it throws the error saying - 
```
Drupal\simple_oauth\Service\Exception\FilesystemValidationException:     [error]
--
  | Directory "private://" is not a valid directory. in /app/docroot/modules/contrib/simple_oauth/src/Service/Filesystem/FilesystemValidator.php:54
```
The function `generateOauthKeys()` needs to prepare the private directory as well just like how it is done in `generateEnvKeys()`
