### PR TITLE
[SDPA-4946] Fixed indentation errors.

### DIFF
--- a/modules/tide_oauth/drush.services.yml
+++ b/modules/tide_oauth/drush.services.yml
@@ -2,5 +2,5 @@ services:
   tide_oauth.commands:
     class: \Drupal\tide_oauth\Commands\TideOauthCommands
     arguments: ['@tide_oauth.env_key_generator']
-      tags:
-        - { name: drush.command }
+    tags:
+      - { name: drush.command }


### PR DESCRIPTION
```
In YamlPecl.php line 74:

  yaml_parse(): parsing error encountered during parsing: did not find expect
  ed key (line 5, column 7), context while parsing a block mapping (line 3, c
  olumn 5)
```
On upgrade of Drush the above error was thrown for any Drush commands.

Cause was extra indents in the updated file