### PR TITLE
[SDPA-5028] Added tablefield modules and related permissions.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -50,6 +50,7 @@
         "drupal/smart_trim": "^1.1",
         "drupal/smtp": "^1.0@RC",
         "drupal/stage_file_proxy": "1.0-rc2",
+        "drupal/tablefield": "2.2",
         "drupal/token_conditions": "dev-1.x",
         "drupal/token_filter": "^1.1",
         "drupal/twig_field_value": "^1.1",
@@ -117,6 +118,9 @@
             },
             "drupal/simple_oauth": {
                 "access:false even though permission is checked for the role - https://www.drupal.org/project/simple_oauth/issues/2958159#comment-13847450": "https://www.drupal.org/files/issues/2020-10-05/simple_oauth-refresh_token_authenticated_missing_scope-2958159-4.patch"
+            },
+            "drupal/tablefield": {
+                "[UX] Add the ability to hide or disable the import CSV option - https://www.drupal.org/project/tablefield/issues/2337743": "https://www.drupal.org/files/issues/2020-11-11/tablefield-allowed_data_sources-2337743-16.patch"
             },
             "drupal/viewsreference": {
                 "Updating from alpha4 to alpha5 via composer results in error - https://www.drupal.org/project/viewsreference/issues/3096956#comment-13370643": "https://www.drupal.org/files/issues/2019-11-28/3096956-17.Unmet-service-dependencies.patch"

--- a/tide_core.install
+++ b/tide_core.install
@@ -1063,3 +1063,18 @@ function tide_core_update_8044() {
     }
   }
 }
+
+/**
+ * Enable tablefield module.
+ */
+function tide_core_update_8045() {
+  if (!\Drupal::moduleHandler()->moduleExists('tablefield')) {
+    $module_installer = \Drupal::service('module_installer');
+    $module_installer->install(['tablefield']);
+  }
+  $roles = ['approver', 'site_admin', 'editor'];
+  $permissions = ['addrow tablefield', 'rebuild tablefield'];
+  foreach ($roles as $role) {
+    user_role_grant_permissions(Role::load($role)->id(), $permissions);
+  }
+}


### PR DESCRIPTION
### Jira
https://digital-engagement.atlassian.net/browse/SDPA-5028

### Changes
Added a new module named tablefield, this is used in tide_landing_page data table PR.

### Related PR
tide_landing_page - https://github.com/dpc-sdp/tide_landing_page/pull/136

Testing link - https://nginx-php.pr-1072.content-vic.sdp1.sdp.vic.gov.au/

### Screenshot
![Screen Shot 2021-04-07 at 5 40 56 pm](https://user-images.githubusercontent.com/20810541/113829411-d0f67c00-97c8-11eb-86c4-8bfdd3b2f7e0.png)
