### PR TITLE
Updates xxs patch

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -82,7 +82,7 @@
                 "Make the DateTime input format and descriptive text consistent - https://www.drupal.org/project/drupal/issues/2791693#comment-13024583": "https://www.drupal.org/files/issues/2019-03-16/2791693-38.patch",
                 "Content types are ordered by machine name on node/add - https://www.drupal.org/project/drupal/issues/2693485#comment-11004325": "https://www.drupal.org/files/issues/2693485-node-3.patch",
                 "Poor performance when using moderation state views filter - https://www.drupal.org/project/drupal/issues/3097303#comment-13559283": "https://www.drupal.org/files/issues/2020-04-17/3097303-9.patch",
-                "Refactor Xss::attributes() to allow filtering of style attribute values - https://www.drupal.org/project/drupal/issues/3109650": "https://www.drupal.org/files/issues/2020-06-26/refactor_xss_attributes-3109650.patch"
+                "Refactor Xss::attributes() to allow filtering of style attribute values - https://www.drupal.org/project/drupal/issues/3109650": "https://www.drupal.org/files/issues/2021-04-21/refactor_xss_attributes-3109650-23.patch"
             },
             "drupal/entity_embed": {
                 "More defensive handling of data-entity-embed-display-settings - https://www.drupal.org/project/entity_embed/issues/3010942": "https://www.drupal.org/files/issues/2019-12-11/3077225-10.reduce-invalid-config-logs.patch"


### PR DESCRIPTION
###  Motivation
1. Drupalcore releases the latest version recently, unfortunately the XXS patch conflicts with the SA-CORE-2021-002 change in 8.9.14. , so we need to update`Refactor Xss::attributes() to allow filtering of style attribute values - https://www.drupal.org/project/drupal/issues/3109650`.
   - https://www.drupal.org/project/drupal/issues/3109650#comment-14068145
2. without updating, a fatal error occurs during `composer update`.
3. sorry about https://github.com/dpc-sdp/tide_core/pull/221, it doesn't correct.