### PR TITLE
Added and updated missing required CKEditor plugins packages.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,9 +6,9 @@
     "minimum-stability": "dev",
     "prefer-stable": true,
     "require": {
-        "ckeditor/fakeobjects": "^4.5.11",
-        "ckeditor/iframe": "^4.5.11",
-        "ckeditor/liststyle": "4.8.0",
+        "ckeditor/fakeobjects": "4.16.0",
+        "ckeditor/iframe": "4.16.0",
+        "ckeditor/liststyle": "4.16.0",
         "drupal/address": "^1.4",
         "drupal/allowed_formats": "^1.1",
         "drupal/better_exposed_filters": "^3.0-alpha5",
@@ -72,6 +72,67 @@
         "drupal": {
             "type": "composer",
             "url": "https://packages.drupal.org/8"
+        },
+        "package/ckeditor-fakeobjects": {
+            "type": "package",
+            "package": {
+                "name": "ckeditor/fakeobjects",
+                "type": "drupal-library",
+                "version": "4.16.0",
+                "dist": {
+                    "type": "zip",
+                    "url": "https://download.ckeditor.com/iframe/releases/iframe_4.16.0.zip",
+                    "reference": "master"
+                },
+                "require": {
+                    "composer/installers": "~1.0"
+                }
+            }
+        },
+        "package/ckeditor-iframe": {
+            "type": "package",
+            "package": {
+                "name": "ckeditor/iframe",
+                "type": "drupal-library",
+                "version": "4.16.0",
+                "dist": {
+                    "type": "zip",
+                    "url": "https://download.ckeditor.com/iframe/releases/iframe_4.16.0.zip",
+                    "reference": "master"
+                },
+                "require": {
+                    "composer/installers": "~1.0"
+                }
+            }
+        },
+        "package/ckeditor-liststyle": {
+            "type": "package",
+            "package": {
+                "name": "ckeditor/liststyle",
+                "type": "drupal-library",
+                "version": "4.16.0",
+                "dist": {
+                    "type": "zip",
+                    "url": "https://download.ckeditor.com/liststyle/releases/liststyle_4.16.0.zip",
+                    "reference": "master"
+                },
+                "require": {
+                    "composer/installers": "~1.0"
+                }
+            }
+        },
+        "package/ckeditor-templates": {
+            "type": "package",
+            "package": {
+                "name": "ckeditor/templates",
+                "type": "drupal-library",
+                "version": "4.11.1",
+                "dist": {
+                    "type": "zip",
+                    "url": "https://download.ckeditor.com/templates/releases/templates_4.11.1.zip",
+                    "reference": "master"
+                }
+            }
         }
     },
     "extra": {


### PR DESCRIPTION
Hi,

Upon composer install with clean Drupal installation I get this:

```
Your requirements could not be resolved to an installable set of packages.

  Problem 1
    - The requested package ckeditor/fakeobjects could not be found in any version, there may be a typo in the package name.
  Problem 2
    - The requested package ckeditor/iframe could not be found in any version, there may be a typo in the package name.
  Problem 3
    - The requested package ckeditor/liststyle could not be found in any version, there may be a typo in the package name.
  Problem 4
    - drupal/wysiwyg_template 2.3.0 requires ckeditor/templates 4.11.1 -> no matching package found.
 ```

### The issue
This seems to the same issue reported in #216, however that one only resolved one of the packages.

- `composer.json` files requires the packages as `ckeditor/[package-name]` (e.g. `"ckeditor/fakeobjects": "^4.5.11"), however there's no repository specified from which to pull these dependencies.
- `composer.json` requires `"drupal/wysiwyg_template": "^2.0@beta"`, which in turn requires `"ckeditor/templates": "4.11.1"`. There's no repository specified, and module's description instructs to manually add the repository. ([see here](https://www.drupal.org/project/wysiwyg_template))

### The solution
- Added missing repositories so that the module can be installed.
- Bumped up and locked the versions of the packages (since they cannot leverage version ranges - there's no point in doing that).
- Added specific version of `ckeditor/templates` since it is pinned by  `drupal/wysiwyg_template`.

### Context
- Drupal version: 8.9.14
- Installed Profile: Standard
- Installed extra modules: tide_core
