### PR TITLE
[DDS-812] : Fix missing dependency

### DIFF
--- a/tide_core.info.yml
+++ b/tide_core.info.yml
@@ -20,6 +20,7 @@ dependencies:
   - drupal:dynamic_page_cache
   - drupal:entity_embed
   - drupal:filter
+  - drupal:link_field_autocomplete_filter
   - drupal:media
   - drupal:node
   - drupal:options


### PR DESCRIPTION
Changed:
1) Added drupal:link_field_autocomplete_filter as a dependency.