### PR TITLE
Fixed tide_core_update_8018 and update_8032.

### DIFF
--- a/tide_core.install
+++ b/tide_core.install
@@ -817,6 +817,9 @@ function tide_core_update_8031() {
 function tide_core_update_8032() {
   // Changes media view.
   $media_view = \Drupal::configFactory()->getEditable('views.view.media');
+  if ($media_view->isNew()) {
+    return;
+  }
   $display = $media_view->get('display');
   $display['default']['display_options']['fields']['changed']['settings']['date_format'] = 'custom';
   $display['default']['display_options']['fields']['changed']['settings']['custom_date_format'] = 'd/m/Y - H:i';

--- a/tide_core.install
+++ b/tide_core.install
@@ -59,11 +59,14 @@ function tide_core_install() {
   // Update default Editorial workflow of Content Moderation.
   _tide_core_update_editorial_workflow();
 
+  $excluded = [
+    'tide_core_update_8015',
+  ];
   $functions = get_defined_functions();
   foreach ($functions['user'] as $function) {
     if (strpos($function, 'tide_core_update_') === 0) {
       // We don't want the tide_core_update_8015 to run during the CI.
-      if ($function == 'tide_core_update_8015') {
+      if (in_array($function, $excluded)) {
         continue;
       }
       call_user_func($function);
@@ -461,6 +464,9 @@ function tide_core_update_8018() {
   ];
   $config_factory = \Drupal::configFactory();
   $config = $config_factory->getEditable('views.view.scheduled_transitions');
+  if ($config->isNew()) {
+    return;
+  }
   // Update field labels/titles.
   foreach ($title_fields as $field) {
     $config->set($field, 'Scheduled update list');


### PR DESCRIPTION
When the `scheduled_transitions` view is yet available during fresh installation, `tide_core_update_8018` creates a malformed View with the following config YML:
```yml
label: 'Scheduled update list'
display:
  default:
    display_options:
      title: 'Scheduled update list'
      empty:
        area:
          content:
            value: 'There are no scheduled updates yet.'
            format: plain_text
```
This is problematic as it prevents Drupal from importing the correct View upon `drush cim` due to the following error:
```
Error: Call to a member function setSyncing() on null in /app/docroot/core/lib/Drupal/Core/Config/Entity/ConfigEntityStorage.php on line 389 #0 /app/docroot/core/lib/Drupal/Core/Config/ConfigImporter.php(997): Drupal\Core\Config\Entity\ConfigEntityStorage->importDelete('views.view.sche...', Object(Drupal\Core\Config\Config), Object(Drupal\Core\Config\Config))
```

The same error occurs in `tide_core_update_8032` for `media` view.

This issue is observed in the newly provisioned project `content-health-vic-gov-au`.

On-behalf-of: @salsadigitalauorg <sonny@salsadigital.com.au>