### PR TITLE
[SRM-24] Added hooks to grant view for unpublished nodes.

### DIFF
--- a/tide_core.module
+++ b/tide_core.module
@@ -358,3 +358,60 @@ function tide_core_menu_link_content_access(EntityInterface $menu_link_item, $op
     }
   }
 }
+
+/**
+ * Implements hook_node_access_records().
+ */
+function tide_core_node_access_records(NodeInterface $node) {
+  // Only run if the module permission by terms is enabled.
+  if (\Drupal::moduleHandler()->moduleExists('permissions_by_term')) {
+    if (!$node->isPublished()) {
+      $grants[] = [
+        'realm' => 'tide_core',
+        'gid' => 1,
+        'grant_view' => 1,
+        'grant_update' => 0,
+        'grant_delete' => 0,
+        'nid' => $node->id(),
+      ];
+
+      return $grants;
+    }
+  }
+  return [];
+}
+
+/**
+ * Implements hook_node_grants().
+ */
+function tide_core_node_grants(AccountInterface $account, $op) {
+  // Only run if the module permission by terms is enabled.
+  if (\Drupal::moduleHandler()->moduleExists('permissions_by_term')) {
+    if ($op === 'view') {
+      $view_unpublished_content_roles = array_keys(user_roles(TRUE, 'view any unpublished content'));
+      $account_roles = $account->getRoles();
+      if (!empty(array_intersect($account_roles, $view_unpublished_content_roles))) {
+        $grants['tide_core'][] = 1;
+
+        return $grants;
+      }
+    }
+  }
+  return [];
+}
+
+/**
+ * Implements hook_node_access().
+ */
+function tide_core_node_access(NodeInterface $node, $op, AccountInterface $account) {
+  // Only run if the module permission by terms is enabled.
+  if (\Drupal::moduleHandler()->moduleExists('permissions_by_term')) {
+    if (!$node->isPublished() && $op === 'view') {
+      $access_result = AccessResult::allowedIfHasPermission($account, 'view any unpublished content');
+      $access_result = $access_result->andIf(AccessResult::allowedIf($node->getOwnerId() == $account->id() || $node->getRevisionUserId() == $account->id()));
+
+      return $access_result->addCacheableDependency($node);
+    }
+  }
+  return AccessResult::neutral()->addCacheableDependency($node);
+}


### PR DESCRIPTION
### Jira
https://digital-engagement.atlassian.net/browse/SRM-24

### Changes
Added hook_node_access_records(), hook_node_grants() and hook_node_access() to allow users to view unpublished contents if they have the right permissions.
