### PR TITLE
[SRM-40] Fixes `modal items` missing issue

### DIFF
--- a/modules/tide_paragraphs_enhanced_modal/css/paragraphs.enhanced_modal.css
+++ b/modules/tide_paragraphs_enhanced_modal/css/paragraphs.enhanced_modal.css
@@ -51,10 +51,10 @@
 
 @media screen and (max-height: 1024px) {
   .paragraphs-add-dialog-enhanced {
-    max-height: 600px !important;
+    max-height: 90vh !important;
   }
   .paragraphs-add-dialog-enhanced .paragraphs-add-dialog-list {
-    max-height: 600px;
+    max-height: 85vh;
   }
 }
 


### PR DESCRIPTION
### Jira
https://digital-engagement.atlassian.net/browse/SRM-40

### Issue 
When the browser at 601-605 height, some of items in the bottom cannot be reached, and the modal title will be gone.