### PR TITLE
[DDS-245] Fix wrong timezone is configured after a site install

### DIFF
--- a/tide_core.install
+++ b/tide_core.install
@@ -53,6 +53,12 @@ function tide_core_install() {
     ->set('register', USER_REGISTER_ADMINISTRATORS_ONLY)
     ->save(TRUE);
 
+  // Change timezone to Australia/Melbourne.
+  \Drupal::configFactory()
+    ->getEditable('system.date')
+    ->set('timezone.default', 'Australia/Melbourne')
+    ->save(TRUE);
+
   // Creates terms for Topic vocabulary.
   _tide_core_create_topic_terms();
 


### PR DESCRIPTION
Jira: https://digital-engagement.atlassian.net/browse/DDS-245

1. Add system.date.yml (copied from content VT)
![image](https://user-images.githubusercontent.com/9244829/125558821-4c65d2e2-42cb-406a-8870-441fb1987b71.png)
