### PR TITLE
Only allowed Admin to register new users.

### DIFF
--- a/tests/behat/features/account.feature
+++ b/tests/behat/features/account.feature
@@ -7,6 +7,6 @@ Feature: Access settings
   Scenario: User creation require admin approval.
     Given I am logged in as a user with the "administrator" role
     When I go to "/admin/config/people/accounts"
-    And I see field "edit-user-register-visitors-admin-approval"
-    And the "edit-user-register-visitors-admin-approval" checkbox should be checked
+    And I see field "edit-user-register-admin-only"
+    And the "edit-user-register-admin-only" checkbox should be checked
     Then I save screenshot

--- a/tide_core.install
+++ b/tide_core.install
@@ -1240,3 +1240,19 @@ function tide_core_update_8050() {
 
   $config->save();
 }
+
+/**
+ * Make user creation require admin approval.
+ */
+function tide_core_update_8051() {
+  // Don't do anything else during config sync.
+  if (\Drupal::isConfigSyncing()) {
+    return;
+  }
+
+  // Restrict user registration to admin role creation.
+  \Drupal::configFactory()
+    ->getEditable('user.settings')
+    ->set('register', USER_REGISTER_ADMINISTRATORS_ONLY)
+    ->save(TRUE);
+}


### PR DESCRIPTION
Jira: 
https://digital-engagement.atlassian.net/browse/SDPA-4393

[SDPA-4393] Added a hook_update to set the user register to admin_only.

The following updates are pending:
tide_core module :
  8050 -   Make user creation admin_only.
Do you wish to run all pending updates? (y/n): y
Finished performing updates.
![Screenshot 2021-08-05 at 2 47 40 PM](https://user-images.githubusercontent.com/83997348/128325533-3ffe5e31-2f7f-4a3a-bdbb-e9432c1da927.png)



On-behalf-of: @salsadigitalauorg <joshua.fernandes@salsadigital.com.au>"

[SDPA-4393]: https://digital-engagement.atlassian.net/browse/SDPA-4393