### PR TITLE
Replaces event_log_track hooks with admin_audit_trail

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,6 +31,7 @@
         "drupal/entity_reference_revisions": "~1.6.0",
         "drupal/entity_embed": "^1.0.0-beta2",
         "drupal/environment_indicator": "^3.5",
+        "drupal/admin_audit_trail": "^1.0",
         "drupal/events_log_track": "^1.1",
         "drupal/fakeobjects": "^1.0",
         "drupal/fast_404": "^1.0-alpha4",

--- a/tide_core.info.yml
+++ b/tide_core.info.yml
@@ -37,15 +37,15 @@ dependencies:
   - entity_browser:entity_browser_entity_form
   - entity_reference_revisions:entity_reference_revisions
   - quick_node_clone:quick_node_clone
-  - events_log_track:event_log_track
-  - events_log_track:event_log_track_auth
-  - events_log_track:event_log_track_node
-  - events_log_track:event_log_track_taxonomy
-  - events_log_track:event_log_track_menu
-  - events_log_track:event_log_track_file
-  - events_log_track:event_log_track_media
-  - events_log_track:event_log_track_user
-  - events_log_track:event_log_track_workflows
+  - admin_audit_trail:admin_audit_trail
+  - admin_audit_trail:admin_audit_trail_auth
+  - admin_audit_trail:admin_audit_trail_node
+  - admin_audit_trail:admin_audit_trail_taxonomy
+  - admin_audit_trail:admin_audit_trail_menu
+  - admin_audit_trail:admin_audit_trail_file
+  - admin_audit_trail:admin_audit_trail_media
+  - admin_audit_trail:admin_audit_trail_user
+  - admin_audit_trail:admin_audit_trail_workflows
   - fakeobjects:fakeobjects
   - fast_404:fast404
   - link_field_autocomplete_filter:link_field_autocomplete_filter


### PR DESCRIPTION
### Jira
https://digital-engagement.atlassian.net/browse/SDPA-5632

### Motivation
1.  `event_log_track` module doesn't have Drupal 9 support, so we are going to switch to admin_audit_trail 

### Change
1. replace `event_log_track` related code by `admin_audit_trail` one.
2. all `event_log_track` patches are merged to `admin_audit_trail`.

### Next
1. This PR is just for disabling event_log_track  and enabling admin_audit_trail.
1. removing event_log_track from composer.json should happen in an another separate hotfix/release.