### PR TITLE
Removed an unnecessary dependency

### DIFF
--- a/tide_core.info.yml
+++ b/tide_core.info.yml
@@ -76,7 +76,6 @@ dependencies:
   - scheduled_transitions:scheduled_transitions
   - dynamic_entity_reference:dynamic_entity_reference
   - admin_audit_trail:admin_audit_trail
-  - block_inactive_users:block_inactive_users
 themes:
   - seven
 config_devel:


### PR DESCRIPTION
### NO ticket.

### Motivation
1. `block_inactive_users` should get activated from `tide_block_inactive_users` module rather than tide_core.

### Change
1. removed `block_inactive_users` from `tide_core.info.yml`