### PR TITLE
Added better exposed filters dependencies.

### DIFF
--- a/tide_core.install
+++ b/tide_core.install
@@ -1301,7 +1301,7 @@ function tide_core_update_8052() {
 
 /**
  * Enable better_exposed_filters module's dependencies.
- * 
+ *
  * @see https://www.drupal.org/project/better_exposed_filters/issues/3109536#comment-13737523
  */
 function tide_core_update_8053() {


### PR DESCRIPTION
### Issue
The better_exposed_filter module added dependency modules. But they didn't add any updated hook to enable them for the projects that are using this module. Rather they have asked to enable it by the project itlsef.

### Issue link 
https://www.drupal.org/project/better_exposed_filters/issues/3109536#comment-13737523

### Changes 
Added update hook to enable the dependency modules for better_expose_filters