### PR TITLE
[SDPA-5664] Redirect "Edit menu" page to menu collection on save

### DIFF
--- a/tide_core.module
+++ b/tide_core.module
@@ -144,7 +144,7 @@ function tide_core_form_alter(&$form, FormStateInterface $form_state, $form_id) 
     }
   }
   if ($form_id === 'menu_edit_form') {
-    if(isset($form_state->getUserInput()['op'])) {
+    if (isset($form_state->getUserInput()['op'])) {
       if ($form_state->getUserInput()['op'] === 'Save') {
         $form['actions']['submit']['#submit'][] = 'tide_core_menu_submit_handler';
       }
@@ -153,14 +153,14 @@ function tide_core_form_alter(&$form, FormStateInterface $form_state, $form_id) 
 }
 
 /**
- * Redirect form upon saving to the Menu UI Module collection
+ * Redirect form upon saving to the Menu UI Module collection.
  *
- * @param $form
- * @param $form_state
+ * @param array $form
+ * @param FormStateInterface $form_state
  */
-function tide_core_menu_submit_handler(&$form, $form_state) {
-    $url = Url::fromRoute('entity.menu.collection');
-    $form_state->setRedirectUrl($url);
+function tide_core_menu_submit_handler(&$form, FormStateInterface $form_state) {
+  $url = Url::fromRoute('entity.menu.collection');
+  $form_state->setRedirectUrl($url);
 }
 
 /**

--- a/tide_core.module
+++ b/tide_core.module
@@ -143,6 +143,24 @@ function tide_core_form_alter(&$form, FormStateInterface $form_state, $form_id) 
       }
     }
   }
+  if ($form_id === 'menu_edit_form') {
+    if(isset($form_state->getUserInput()['op'])) {
+      if ($form_state->getUserInput()['op'] === 'Save') {
+        $form['actions']['submit']['#submit'][] = 'tide_core_menu_submit_handler';
+      }
+    }
+  }
+}
+
+/**
+ * Redirect form upon saving to the Menu UI Module collection
+ *
+ * @param $form
+ * @param $form_state
+ */
+function tide_core_menu_submit_handler(&$form, $form_state) {
+    $url = Url::fromRoute('entity.menu.collection');
+    $form_state->setRedirectUrl($url);
 }
 
 /**

--- a/tide_core.module
+++ b/tide_core.module
@@ -154,9 +154,6 @@ function tide_core_form_alter(&$form, FormStateInterface $form_state, $form_id) 
 
 /**
  * Redirect form upon saving to the Menu UI Module collection.
- *
- * @param array $form
- * @param FormStateInterface $form_state
  */
 function tide_core_menu_submit_handler(&$form, FormStateInterface $form_state) {
   $url = Url::fromRoute('entity.menu.collection');

--- a/tide_core.module
+++ b/tide_core.module
@@ -146,7 +146,7 @@ function tide_core_form_alter(&$form, FormStateInterface $form_state, $form_id) 
   if ($form_id === 'menu_edit_form') {
     if (isset($form_state->getUserInput()['op'])) {
       if ($form_state->getUserInput()['op'] === 'Save') {
-        $form['actions']['submit']['#submit'][] = 'tide_core_menu_submit_handler';
+        $form['actions']['submit']['#submit'][] = '_tide_core_menu_submit_handler';
       }
     }
   }
@@ -155,7 +155,7 @@ function tide_core_form_alter(&$form, FormStateInterface $form_state, $form_id) 
 /**
  * Redirect form upon saving to the Menu UI Module collection.
  */
-function tide_core_menu_submit_handler(&$form, FormStateInterface $form_state) {
+function _tide_core_menu_submit_handler(&$form, FormStateInterface $form_state) {
   $url = Url::fromRoute('entity.menu.collection');
   $form_state->setRedirectUrl($url);
 }


### PR DESCRIPTION
JIRA: https://digital-engagement.atlassian.net/browse/SDPA-5664

Changes:
1) When the CMS user edits a menu item and saves it, the user is redirected to the menu collections page.
2) The function "tide_core_menu_submit_handler" is added for the redirect as the "$form_state->setRedirectUrl(<URL>) function if added in the "tide_core_form_alter" function in tide_core.module does not set the redirect.


Test PR: https://github.com/dpc-sdp/content-vic-gov-au/pull/1264