### PR TITLE
Feature/sdpa 6029 copy paste wysiwg

### DIFF
--- a/modules/tide_spell_checker/tide_spell_checker.settings.php
+++ b/modules/tide_spell_checker/tide_spell_checker.settings.php
@@ -13,7 +13,19 @@ if ($env_vars) {
   foreach ($env_vars as $var => $value) {
     if (str_contains($var, 'CKEDITOR_')) {
       $var = strtolower(trim(str_replace('CKEDITOR_', '', $var)));
-      $var = ($var == 'scayt_slang') ? 'scayt_sLang' : $var;
+      switch ($var) {
+        case 'scayt_slang':
+          $var = 'scayt_sLang';
+          break;
+
+        case 'forcepasteasplaintext':
+          $var = 'forcePasteAsPlainText';
+          break;
+
+        case 'pastefilter':
+          $var = 'pasteFilter';
+          break;
+      }
       $array_of_config[$var] = $value;
     }
   }


### PR DESCRIPTION
**JIRA issue:** https://digital-engagement.atlassian.net/browse/SDPA-6029

### Background
Copying and pasting are normally done between WYSIWG editor and users would like to keep most of the formatting.

The solution would ease their daily work if those formatting are retained.
There will be some cases where they have to manually edit some formatting as agreed.

https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR_config.html#cfg-forcePasteAsPlainText
https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR_config.html#cfg-pasteFilter

### Requirements
The following formatting items are to be included:
- bold
- italics
- strike-through
- H1, H2, H3, H4, H5
- hyperlinked text
- ordered lists
- unordered lists
- block quotes
- call out
- table

### Screenshots
CKEDITOR custom configuration
![image](https://user-images.githubusercontent.com/67810118/165192406-3bfc97ff-856a-41b7-8f60-7bda0c0172a5.png)


example from https://nginx-php.pr-68.content-reference-sdp-vic-gov-au.sdp2.sdp.vic.gov.au/node/24/edit

![image](https://user-images.githubusercontent.com/67810118/165192280-9c8647a2-f21d-4586-a50d-d395f4174620.png)

FE:
![image](https://user-images.githubusercontent.com/67810118/165434314-5104b822-0210-4f11-a0fd-8b25f36e5368.png)

DevTools
![image](https://user-images.githubusercontent.com/67810118/165434443-458584de-7529-42c6-9a2b-82a7c7122fbb.png)


