### PR TITLE
[SDPA-5969] Make CMS user email required during user creation

### DIFF
--- a/tide_core.module
+++ b/tide_core.module
@@ -175,6 +175,15 @@ function tide_core_form_scheduled_transition_delete_form_alter(&$form, FormState
 }
 
 /**
+ * Implements hook_form_FORM_ID_alter().
+ */
+function tide_core_form_user_register_form_alter(&$form, FormStateInterface $form_state, $form_id) {
+  if (isset($form['account']['mail']['#required'])) {
+    $form['account']['mail']['#required'] = true;
+  }
+}
+
+/**
  * Submit handler for altering updating status message.
  */
 function _tide_core_modified_update_adding_message(&$form, $form_state) {

--- a/tide_core.module
+++ b/tide_core.module
@@ -179,7 +179,7 @@ function tide_core_form_scheduled_transition_delete_form_alter(&$form, FormState
  */
 function tide_core_form_user_register_form_alter(&$form, FormStateInterface $form_state, $form_id) {
   if (isset($form['account']['mail']['#required'])) {
-    $form['account']['mail']['#required'] = true;
+    $form['account']['mail']['#required'] = TRUE;
   }
 }
 


### PR DESCRIPTION
**JIRA** - https://digital-engagement.atlassian.net/browse/SDPA-5969

Changes
1) Make the email field required for all user types when creating a new user.

![image](https://user-images.githubusercontent.com/9244829/166867664-2e58fabc-b1e8-43c6-9330-84f312e470cb.png)
