### PR TITLE
Fixed fatal error from tide_edit_protection_preprocess_status_messages.

### DIFF
--- a/modules/tide_edit_protection/tide_edit_protection.module
+++ b/modules/tide_edit_protection/tide_edit_protection.module
@@ -164,7 +164,7 @@ function tide_edit_protection_content_lock_timeout_message_alter(&$message, $con
 function tide_edit_protection_preprocess_status_messages(&$variables) {
   if ($variables && isset($variables['message_list']) && isset($variables['message_list']['status'])) {
     foreach ($variables['message_list']['status'] as $key => $message) {
-      if (strpos($message->__toString(), 'This content is now locked by you against simultaneous editing') !== FALSE) {
+      if (strpos((string) $message, 'This content is now locked by you against simultaneous editing') !== FALSE) {
         $variables['message_list']['status'][$key] = t('This content is locked against simultaneous editing. It will remain locked if you navigate away from this page without saving or unlocking it.');
       }
     }


### PR DESCRIPTION
Fix error:
```
Error: Call to a member function __toString() on string in tide_edit_protection_preprocess_status_messages() (line 167 of /app/docroot/modules/contrib/tide_core/modules/tide_edit_protection/tide_edit_protection.module)
#0 /app/docroot/core/lib/Drupal/Core/Theme/ThemeManager.php(287): tide_edit_protection_preprocess_status_messages(Array, 'status_messages', Array)
#1 /app/docroot/core/lib/Drupal/Core/Render/Renderer.php(436): Drupal\Core\Theme\ThemeManager->render('status_messages', Array)
```