### PR TITLE
cherry-pick: [SDPA-5443] Tide Core Common Services Helper

### DIFF
--- a/src/TideCommonServices.php
+++ b/src/TideCommonServices.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Drupal\tide_core;
+
+/**
+ * Provides helper functions for file.
+ *
+ * @package Drupal\tide_core
+ */
+class TideCommonServices {
+
+  /**
+   * Helper to sanitise spaces in filename.
+   *
+   * Option to include replacement as part of regular expression.
+   *
+   * @param string $filename
+   *   Filename to sanitise.
+   * @param string $replacement
+   *   Value to replace spaces in the filename.
+   * @param bool $include_in_pattern
+   *   (optional) Flag to include replacement value in sanitise.
+   *   Defaults to TRUE.
+   *
+   * @return string
+   *   Sanitised filename.
+   */
+  public function sanitiseFileName($filename, $replacement, $include_in_pattern = TRUE) {
+    $pattern = $include_in_pattern ? '/[\s' . $replacement . ']+/' : '/[\s]+/';
+    return preg_replace($pattern, $replacement, $filename);
+  }
+
+}

--- a/tests/src/Unit/TideCommonServicesTest.php
+++ b/tests/src/Unit/TideCommonServicesTest.php
@@ -1,0 +1,82 @@
+<?php
+
+namespace Drupal\Tests\tide_core\Unit;
+
+use Drupal\Tests\UnitTestCase;
+use Drupal\tide_core\TideCommonServices;
+
+/**
+ * Main test class for common functions.
+ */
+class TideCommonServicesTest extends UnitTestCase {
+
+  /**
+   * @covers ::sanitiseFileName
+   * @dataProvider fileNameProvider
+   */
+  public function testSanitiseFileName($value, $replacement, $include_in_pattern, $expected) {
+    $tideCommonServices = new TideCommonServices();
+    $filename = $tideCommonServices->sanitiseFileName($value, $replacement, $include_in_pattern);
+    $this->assertEquals($expected, $filename);
+  }
+
+  /**
+   * Data provider of test sanitise.
+   *
+   * @return array
+   *   Array of values.
+   */
+  public function fileNameProvider() {
+    return [
+      [
+        'value' => 'file with spaces only.pdf',
+        'replacement' => '-',
+        'include_in_pattern' => FALSE,
+        'expected' => 'file-with-spaces-only.pdf',
+      ],
+      [
+        'value' => 'file with spaces only.pdf',
+        'replacement' => '-',
+        'include_in_pattern' => TRUE,
+        'expected' => 'file-with-spaces-only.pdf',
+      ],
+      [
+        'value' => 'file - with - spaces - only.pdf',
+        'replacement' => '-',
+        'include_in_pattern' => FALSE,
+        'expected' => 'file---with---spaces---only.pdf',
+      ],
+      [
+        'value' => 'file - with - spaces - only.pdf',
+        'replacement' => '-',
+        'include_in_pattern' => TRUE,
+        'expected' => 'file-with-spaces-only.pdf',
+      ],
+      [
+        'value' => 'file - with- before- spaces and -after -space.pdf',
+        'replacement' => '-',
+        'include_in_pattern' => TRUE,
+        'expected' => 'file-with-before-spaces-and-after-space.pdf',
+      ],
+      [
+        'value' => 'file - with + spaces _ other ~ symbols.pdf',
+        'replacement' => '-',
+        'include_in_pattern' => FALSE,
+        'expected' => 'file---with-+-spaces-_-other-~-symbols.pdf',
+      ],
+      [
+        'value' => 'file - with + spaces _ other ~ symbols.pdf',
+        'replacement' => '-',
+        'include_in_pattern' => TRUE,
+        'expected' => 'file-with-+-spaces-_-other-~-symbols.pdf',
+      ],
+      [
+        'value' => 'site/2020-02/files/file - with - spaces - only.pdf',
+        'replacement' => '-',
+        'include_in_pattern' => TRUE,
+        'expected' => 'site/2020-02/files/file-with-spaces-only.pdf',
+      ],
+    ];
+  }
+
+}

--- a/tide_core.services.yml
+++ b/tide_core.services.yml
@@ -7,3 +7,5 @@ services:
     class: Drupal\tide_core\TideEntityUpdateHelper
     arguments:
       [ '@entity_type.manager', '@entity_field.manager', '@entity.last_installed_schema.repository', '@field_storage_definition.listener' ]
+  tide_core.common_services:
+    class: Drupal\tide_core\TideCommonServices


### PR DESCRIPTION
### Jira
https://digital-engagement.atlassian.net/browse/SW-1640

### Issue
In the content-premier site `3.0.7-p2`, `tide_media` is 3.0.4 which has a feature: https://github.com/dpc-sdp/tide_media/pull/82 that depends on https://github.com/dpc-sdp/tide_core/blob/develop/tide_core.services.yml#L17 service, but `tide_core.common_services` was not included into the release.

### Change
We don't want to include other changes from develop branch, so we cherry-pick the specific change https://github.com/dpc-sdp/tide_core/commit/d298a593dcb700a00f3c268a3a8079ad5b8baba9.


relates to 
   - https://github.com/dpc-sdp/content-premier-vic-gov-au/pull/165
   - https://github.com/dpc-sdp/tide_media/pull/82