### PR TITLE
[SDPA-5959] Move CMS help block install to tide profile

### DIFF
--- a/modules/tide_cms_support/tide_cms_support.install
+++ b/modules/tide_cms_support/tide_cms_support.install
@@ -9,30 +9,6 @@ use Drupal\block\Entity\Block;
 use Drupal\Core\Utility\UpdateException;
 
 /**
- * Implements hook_install().
- */
-function tide_cms_support_install() {
-  // Create Tide CMS Help block.
-  $block = Block::create([
-    'id' => 'admin_tide_cms_help',
-    'theme' => \Drupal::config('system.theme')->get('admin'),
-    'region' => 'help',
-    'weight' => -100,
-    'provider' => NULL,
-    'plugin' => 'tide_help_block',
-    'settings' => [
-      'id' => 'tide_help_block',
-      'label' => 'Tide CMS Help',
-      'label_display' => FALSE,
-      'provider' => 'tide_cms_support',
-    ],
-    'visibility' => [],
-  ]);
-
-  $block->save();
-}
-
-/**
  * Create Tide CMS Help block.
  */
 function tide_cms_support_update_8001() {


### PR DESCRIPTION
Ticket: https://digital-engagement.atlassian.net/browse/SDPA-5959

## Changes

- Remove install CMS Help block from `tide_cms_support`

## Motivation

During fresh install of `tide_core` and `tide_cms_support` the Admin theme is not available, so installation of the CMS Help block fails. 

See error during builds -
<img width="1347" alt="Screen Shot 2022-06-10 at 9 33 18 am" src="https://user-images.githubusercontent.com/452515/172979138-ca7d5a9d-bec4-4767-8edc-e6a8addaaef0.png">

Moving this block placement into the Tide Profile install process where the Admin theme will be available.
