### PR TITLE
[SRM-436] Re roll Metadata module patch for Issue:2945817

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -226,7 +226,7 @@
                 "More defensive handling of data-entity-embed-display-settings - https://www.drupal.org/project/entity_embed/issues/3010942": "https://www.drupal.org/files/issues/2019-12-11/3077225-10.reduce-invalid-config-logs.patch"
             },
             "drupal/metatag": {
-                "Support json api - https://www.drupal.org/project/metatag/issues/2945817": "https://www.drupal.org/files/issues/2021-12-21/metatag-data-type-support-2945817-132.patch"
+                "Support json api - https://www.drupal.org/project/metatag/issues/2945817": "https://www.drupal.org/files/issues/2022-07-13/metatag-data-type-support-2945817-148_0.patch"
             },
             "drupal/token": {
                 "Summary token not fully handled in fields": "https://www.drupal.org/files/issues/tokens.body-with-summary.patch"


### PR DESCRIPTION
**Jira:**  https://digital-engagement.atlassian.net/browse/SRM-436

Changes:

1. Use rerolled patch as metadata module is upgraded to [8.x-1.20](https://www.drupal.org/project/metatag/releases/8.x-1.20)

**Links**
https://www.drupal.org/project/metatag/issues/2945817