### PR TITLE
[DDS-1053] Added Tide Logs

### DIFF
--- a/modules/tide_logs/README.md
+++ b/modules/tide_logs/README.md
@@ -1,0 +1,94 @@
+# Tide Logs
+Provides a SumoLogic handler for Monolog.
+
+## Requirements
+
+  - [Lagoon logs](https://drupal.org/project/lagoon_logs)
+
+
+## Activation
+
+1. The module requires a working [Sumo Logic OTEL Collector](https://github.com/SumoLogic/sumologic-otel-collector) to which it can send logs.
+   1. A helm chart has been created [here](https://github.com/dpc-sdp/sdp-helm-charts/tree/master/charts/sumologic-otel-collector) for easy installation on Kubernetes clusters.
+   2. To test locally, in a test project:
+      1. Create a file at `.docker/sumologic-otel/config.yaml` with the following content:
+          ```yaml
+          extensions:
+            sumologic:
+              # Get from https://service.au.sumologic.com/ui/#/security/installation-tokens
+              install_token: <collector-install-token>
+               # Highly recommend adding a unique suffix, otherwise you might run into conflicts with other collector instances.
+              collector_name: SDP Syslog - OTEL - <random-suffix>
+              clobber: true
+
+          receivers:
+            udplog:
+              listen_address: "0.0.0.0:514"
+              attributes:
+                source_name: "foobar/otel/test"
+              operators:
+                - type: json_parser
+                - type: metadata
+                  id: metadata/source_host
+                  if: '"source_host" in $$body'
+                  attributes:
+                    source_host: 'EXPR($$body.source_host)'
+                - type: metadata
+                  id: metadata/source_category
+                  if: '"source_category" in $$body'
+                  attributes:
+                    source_category: 'EXPR($$body.source_category)'
+
+          processors: {}
+
+          exporters:
+            logging:
+              loglevel: debug
+            sumologic:
+              auth:
+                authenticator: sumologic
+              source_category: "%{source_category}"
+              source_name: "%{source_name}"
+              source_host: "%{source_host}"
+              metadata_attributes:
+                - source.*
+
+          service:
+            extensions: [sumologic]
+            pipelines:
+              logs:
+                receivers: [udplog]
+                exporters: [sumologic]
+
+          ```
+      2. Add a service to `docker-compose.yml` as follows:
+          ```yml
+          sumo-otel:
+            image: "public.ecr.aws/sumologic/sumologic-otel-collector:${SUMO_OTEL_RELEASE_VERSION:-0.47.0-sumo-0}"
+            volumes:
+              - .docker/sumologic-otel:/etc/otel
+            ports:
+              - 514
+            networks:
+              - amazeeio-network
+              - default
+            labels:
+              lagoon.type: none
+          ```
+      3. Running `ahoy up` will register the instance with Sumo Logic; it's now ready to start collecting logs. Run `docker-compose logs -f sumo-otel` to make sure there were no errors. The last line should be something like
+          ```
+          Everything is ready. Begin running and processing data.
+          ```
+2. Enable the Tide Logs module. Go to `/admin/config/development/tide_logs` and ensure `UDPlog host` and `UDPlog port` correspond to the service's name and the port in the `config.yaml` respectively, if running with docker-compose. The module's default is `udp://logs-forwarder.sdp-services.svc:5514` (see the default config [here](config/install/tide_logs.settings.yml)).
+3. `SUMOLOGIC_CATEGORY` can also be set if a different category from the default (`sdp/dev/tide`) is required.
+4. The following search query can then be used in SumoLogic to view the logs:
+   ```
+   _collector="SDP Syslog - OTEL - <random-suffix>" and _sourceCategory="sdp/dev/tide"
+   ```
+
+## Debug
+
+Some very basic debug messages can be printed locally (or remotely if you have drush access) by setting the following config variable:
+```sh
+drush config:set tide_logs.settings debug 1
+```

--- a/modules/tide_logs/config/install/tide_logs.settings.yml
+++ b/modules/tide_logs/config/install/tide_logs.settings.yml
@@ -1,0 +1,5 @@
+enable: true
+host: logs-forwarder.sdp-services.svc
+port: 5514
+sumologic_category: ''
+debug: false

--- a/modules/tide_logs/config/install/tide_logs.settings.yml
+++ b/modules/tide_logs/config/install/tide_logs.settings.yml
@@ -1,5 +1,5 @@
 enable: true
-host: logs-forwarder.sdp-services.svc
+host: sumologic-otel-collector.sdp-services
 port: 5514
 sumologic_category: ''
 debug: false

--- a/modules/tide_logs/config/schema/tide_logs.schema.yml
+++ b/modules/tide_logs/config/schema/tide_logs.schema.yml
@@ -1,0 +1,21 @@
+# Schema for the configuration files of the tide_logs module.
+
+tide_logs.settings:
+  type: config_object
+  label: 'Tide logs settings'
+  mapping:
+    enable:
+      type: boolean
+      label: 'Enabled'
+    host:
+      type: string
+      label: 'UDPLog host'
+    port:
+      type: integer
+      label: 'UDPLog port'
+    sumologic_category:
+      type: string
+      label: 'Sumo Logic category'
+    debug:
+      type: boolean
+      label: 'Show debug messages'

--- a/modules/tide_logs/src/Form/TideLogsSettingsForm.php
+++ b/modules/tide_logs/src/Form/TideLogsSettingsForm.php
@@ -1,0 +1,95 @@
+<?php
+
+namespace Drupal\tide_logs\Form;
+
+use Drupal\Core\Form\ConfigFormBase;
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\tide_logs\Logger\TideLogsLogger;
+use Drupal\Core\Config\ConfigFactoryInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Settings form for tide_logs.
+ */
+class TideLogsSettingsForm extends ConfigFormBase {
+
+  /**
+   * The Tide logger service.
+   *
+   * @var TideLogsLogger
+   */
+  protected TideLogsLogger $tideLogsLogger;
+
+  /**
+   * {@inheritdoc}
+   */
+  public function __construct(ConfigFactoryInterface $config_factory, TideLogsLogger $tide_logs_logger) {
+    parent::__construct($config_factory);
+    $this->tideLogsLogger = $tide_logs_logger;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container) {
+    return new static(
+      $container->get('config.factory'),
+      $container->get('logger.tide_logs')
+    );
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function getEditableConfigNames() {
+    return ['tide_logs.settings'];
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getFormId() {
+    return 'tide_logs_settings_form';
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function buildForm(array $form, FormStateInterface $form_state) {
+    $config = $this->config('tide_logs.settings');
+
+    $form['enable'] = [
+      '#type' => 'checkbox',
+      '#title' => $this->t('Enable module'),
+      '#description' => $this->t('Send logs to SumoLogic.'),
+      '#default_value' => $config->get('enable'),
+    ];
+
+    $form['description'] = [
+      '#prefix' => '<div class="ll-settings-description">',
+      '#suffix' => '</div>',
+      '#markup' => $this->t(
+        '<p>Current settings for the Tide Logs module. The defaults are set in configuration, this page is meant primarily for troubleshooting.</p>' .
+        '<ul>' .
+          '<li><b>' . $this->t('UDPlog host') . ':</b> ' . $config->get('host') . '</li>' .
+          '<li><b>' . $this->t('UDPlog port') . ':</b> ' . $config->get('port') . '</li>' .
+          '<li><b>' . $this->t('SumoLogic category') . ':</b> ' . $this->tideLogsLogger->getSumoLogicCategory() . '</li>' .
+          '<li><b>' . $this->t('SumoLogic host') . ':</b> ' . $this->tideLogsLogger->getSumoLogicHost() . '</li>' .
+        '</ul>'
+      ),
+    ];
+
+    return parent::buildForm($form, $form_state);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function submitForm(array &$form, FormStateInterface $form_state) {
+    parent::submitForm($form, $form_state);
+    $this->config('tide_logs.settings')
+      ->set('enable', $form_state->getValue('enable'))
+      ->save();
+  }
+
+}

--- a/modules/tide_logs/src/Logger/TideLogsFormatter.php
+++ b/modules/tide_logs/src/Logger/TideLogsFormatter.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace Drupal\tide_logs\Logger;
+
+use Monolog\Formatter\JsonFormatter;
+
+/**
+ * Class TideLogsFormatter
+ *
+ * Add SumoLogic fields to the JSON formatter.
+ *
+ * @package Drupal\lagoon_logs\Logger
+ */
+class TideLogsFormatter extends JsonFormatter {
+
+  /**
+   * The host to be sent to SumoLogic.
+   *
+   * @var string
+   */
+  protected string $sourceHost;
+
+  /**
+   * The category to be sent to SumoLogic.
+   *
+   * @var string
+   */
+  protected string $sourceCategory;
+
+  /**
+   * Class constructor.
+   */
+  public function __construct($source_host, $source_category) {
+    parent::__construct();
+    $this->sourceHost = $source_host;
+    $this->sourceCategory = $source_category;
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  public function format(array $record): string {
+    $record = json_decode(parent::format($record), TRUE);
+
+    // Add the SumoLogic attributes.
+    $record['source_host'] = $this->sourceHost;
+    $record['source_category'] = $this->sourceCategory;
+
+    return $this->toJson($record) . "\n";
+  }
+
+}

--- a/modules/tide_logs/src/Logger/TideLogsLogger.php
+++ b/modules/tide_logs/src/Logger/TideLogsLogger.php
@@ -1,0 +1,187 @@
+<?php
+
+namespace Drupal\tide_logs\Logger;
+
+use Monolog\Logger;
+use GuzzleHttp\Client;
+use Monolog\Handler\SocketHandler;
+use Drupal\Core\Config\ImmutableConfig;
+use Drupal\lagoon_logs\LagoonLogsLogProcessor;
+use Drupal\lagoon_logs\Logger\LagoonLogsLogger;
+use Drupal\Core\Logger\LogMessageParserInterface;
+use Drupal\lagoon_logs\Logger\LagoonLogsLoggerFactory;
+
+/**
+ * Defines a logger channel for sending logs to SumoLogic.
+ */
+class TideLogsLogger extends LagoonLogsLogger {
+
+  /**
+   * Default channel name for MonoLog.
+   */
+  public const MONOLOG_CHANNEL_NAME = 'TideLogs';
+
+  /**
+   * Default udplog host.
+   */
+  public const DEFAULT_UDPLOG_HOST = 'logs-forwarder.sdp-services.svc';
+
+  /**
+   * Default udplog port.
+   */
+  public const DEFAULT_UDPLOG_port = 5514;
+
+  /**
+   * Default SumoLogic category.
+   */
+  public const DEFAULT_CATEGORY = 'sdp/dev/tide';
+
+  protected Client $httpClient;
+
+  protected ImmutableConfig $moduleConfig;
+
+  /**
+   * Flag to indicate whether to print debug messages.
+   *
+   * @var boolean
+   */
+  protected bool $showDebug;
+
+  /**
+   * Constructs a TideLogsLogger object.
+   *
+   * @param LogMessageParserInterface $parser
+   *   The log message parser service.
+   * @param Client $http_client
+   *   The http client service.
+   * @param ImmutableConfig $module_config
+   *   The module's config.
+   */
+  public function __construct(
+    LogMessageParserInterface $parser,
+    Client $http_client,
+    $module_config
+  ) {
+    $this->parser = $parser;
+    $this->httpClient = $http_client;
+    $this->moduleConfig = $module_config;
+    $this->hostName = $module_config->get('host') ?: static::DEFAULT_UDPLOG_HOST;
+    $this->hostPort = $module_config->get('port') ?: static::DEFAULT_UDPLOG_port;
+    $this->showDebug = (bool) $module_config->get('debug');
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function log($level, $message, array $context = []) {
+    $sumoLogicHost = $this->getSumoLogicHost();
+    $sumoLogicCategory = $this->getSumoLogicCategory();
+
+    if ($this->showDebug) {
+      \Drupal::messenger()->addMessage(t(
+        'Code: @code; Cat: @cat',
+        [
+          '@cat' => $sumoLogicCategory,
+        ]
+      ));
+    }
+
+    if (empty($sumoLogicHost) || empty($this->hostName) || empty($this->hostPort)) {
+      return;
+    }
+
+    global $base_url;
+
+    $logger = new Logger(
+      !empty($context['channel']) ? $context['channel'] : self::MONOLOG_CHANNEL_NAME
+    );
+
+    $connectionString = sprintf(
+      "udp://%s:%s",
+      $this->hostName,
+      $this->hostPort
+    );
+    $udpHandler = new SocketHandler($connectionString);
+
+    $udpHandler->setChunkSize(self::LAGOON_LOGS_DEFAULT_CHUNK_SIZE_BYTES);
+
+    $udpHandler->setFormatter(
+      new TideLogsFormatter($sumoLogicHost, $sumoLogicCategory)
+    );
+
+    $logger->pushHandler($udpHandler);
+
+    $message_placeholders = $this->parser->parseMessagePlaceholders(
+      $message,
+      $context
+    );
+    $message = strip_tags(
+      empty($message_placeholders) ? $message : strtr(
+        $message,
+        $message_placeholders
+      )
+    );
+
+    $processorData = $this->transformDataForProcessor(
+      $level,
+      $message,
+      $context,
+      $base_url
+    );
+
+    $logger->pushProcessor(new LagoonLogsLogProcessor($processorData));
+
+    try {
+      $logger->log($this->mapRFCtoMonologLevels($level), $message);
+    } catch (\Exception $exception) {
+      if ($this->showDebug) {
+        \Drupal::messenger()->addMessage(t(
+          'Error logging to SumoLogic: @error',
+          ['@error' => $exception->getMessage()]
+        ));
+      }
+    }
+  }
+
+  /**
+   * Determines the host for the log payload.
+   *
+   * Since it uses the LAGOON_PROJECT & LAGOON_GIT_SAFE_BRANCH variables, this
+   * will effectively correspond to the site's kubernetes namespace.
+   *
+   * @return string|boolean
+   *   Either the namespace, or False in case logging is not enabled.
+   */
+  public function getSumoLogicHost() {
+    $enabled = $this->moduleConfig->get('enable');
+    return $enabled ?
+      implode('-', [
+        getenv('LAGOON_PROJECT') ?: LagoonLogsLoggerFactory::LAGOON_LOGS_DEFAULT_LAGOON_PROJECT,
+        getenv('LAGOON_GIT_SAFE_BRANCH') ?: LagoonLogsLoggerFactory::LAGOON_LOGS_DEFAULT_SAFE_BRANCH,
+      ]) :
+      FALSE;
+  }
+
+  /**
+   * Determines the SumoLogic Category to be used as header when sending logs.
+   *
+   * The category can be specified either in settings or as an environment
+   * variable, the latter taking precedence when there are conflicts.
+   *
+   * @return string
+   *   Either the specified category or the default.
+   */
+  public function getSumoLogicCategory() {
+    $enabled = $this->moduleConfig->get('enable');
+    if (!$enabled) {
+      return FALSE;
+    }
+    // Allow category to be specified via environment.
+    $category = getenv('SUMOLOGIC_CATEGORY');
+    if (!$category) {
+      $category = $this->moduleConfig->get('sumologic_category');
+    }
+    return $category ?: static::DEFAULT_CATEGORY;
+  }
+
+}

--- a/modules/tide_logs/src/Logger/TideLogsLoggerFactory.php
+++ b/modules/tide_logs/src/Logger/TideLogsLoggerFactory.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Drupal\tide_logs\Logger;
+
+use GuzzleHttp\Client;
+use Drupal\Core\Config\ConfigFactoryInterface;
+use Drupal\Core\Logger\LogMessageParserInterface;
+
+/**
+ * Defines a logger factory for the SumoLogic channel.
+ */
+class TideLogsLoggerFactory {
+
+  /**
+   * Creates an instance of the SumoLogic logger.
+   *
+   * This method is called in tide_logs.services.yml to initialise the logger.
+   *
+   * @param ConfigFactoryInterface $config
+   *   The config service.
+   * @param LogMessageParserInterface $parser
+   *   The log message parser service.
+   * @param Client $http_client
+   *   The http client service.
+   *
+   * @return TideLogsLogger
+   *    The logger instance that was created.
+   */
+  public static function create(
+    ConfigFactoryInterface $config,
+    LogMessageParserInterface $parser,
+    Client $http_client
+  ) {
+    return new TideLogsLogger(
+      $parser,
+      $http_client,
+      $config->get('tide_logs.settings')
+    );
+  }
+
+}

--- a/modules/tide_logs/tide_logs.info.yml
+++ b/modules/tide_logs/tide_logs.info.yml
@@ -1,0 +1,9 @@
+name: Tide Logs
+description: Simple monolog wrapper for Sumo Logic.
+package: Tide
+configure: tide_logs.settings
+type: module
+core_version_requirement: ^8 || ^9
+
+dependencies:
+  - lagoon_logs:lagoon_logs

--- a/modules/tide_logs/tide_logs.links.menu.yml
+++ b/modules/tide_logs/tide_logs.links.menu.yml
@@ -1,0 +1,5 @@
+system.tide_logs_settings:
+  title: 'Tide Logs settings'
+  parent: system.admin_config_development
+  description: 'Configure Tide Logs.'
+  route_name: tide_logs.settings

--- a/modules/tide_logs/tide_logs.routing.yml
+++ b/modules/tide_logs/tide_logs.routing.yml
@@ -1,0 +1,7 @@
+tide_logs.settings:
+  path: '/admin/config/development/tide_logs'
+  defaults:
+    _form: '\Drupal\tide_logs\Form\TideLogsSettingsForm'
+    _title: 'Tide Logs configuration'
+  requirements:
+    _permission: 'administer site configuration'

--- a/modules/tide_logs/tide_logs.services.yml
+++ b/modules/tide_logs/tide_logs.services.yml
@@ -1,0 +1,7 @@
+services:
+  logger.tide_logs:
+    class: Drupal\tide_logs\Logger\TideLogsLogger
+    factory: Drupal\tide_logs\Logger\TideLogsLoggerFactory::create
+    tags:
+      - { name: logger }
+    arguments: ['@config.factory', '@logger.log_message_parser', '@http_client']


### PR DESCRIPTION
Migrating the new module `tide_logs` from https://github.com/dpc-sdp/ansible-role-sdp-tide-platform/pull/13 to here.

From the original PR testing against a content instance - https://github.com/dpc-sdp/content-vic-gov-au/pull/1322

> 
> Includes a SumoLogic handler.
> 
> **JIRA issue:** https://digital-engagement.atlassian.net/browse/DDS-1053
> 
> ### Changed
> 
> 1.  Added the Tide Logs module which contains a SumoLogic handler for Monolog. To activate, enable the module and set the environment variable `SUMOLOGIC_COLLECTOR_CODE`. `SUMOLOGIC_CATEGORY` can also be set if a different category from the default (`sdp/dev/tide`) is required.
> 2. The following search query can then be used in SumoLogic to view the logs:
>    ```
>    _source="SDP collector" and _collector="SDP" and _sourceCategory="sdp/dev/tide"
>    ```
