### PR TITLE
Test remove inline entity form patch.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -81,6 +81,9 @@
         "lesstif/php-jira-rest-client": "2.6.0",
         "drupal/jira_rest": "^4.0@beta"
     },
+    "provide": {
+        "drupal/ckeditor": "*"
+    },
     "repositories": {
         "drupal": {
             "type": "composer",
@@ -242,9 +245,6 @@
             },
             "drupal/tablefield": {
                 "[UX] Add the ability to hide or disable the import CSV option - https://www.drupal.org/project/tablefield/issues/2337743": "https://www.drupal.org/files/issues/2020-11-11/tablefield-allowed_data_sources-2337743-16.patch"
-            },
-            "drupal/inline_entity_form": {
-                "Preventing multiple submissions - https://www.drupal.org/project/inline_entity_form/issues/3160683#comment-13758454": "https://www.drupal.org/files/issues/2020-07-22/3160683-1.0-rc-6.patch"
             },
             "ckeditor/liststyle": {
                 "Change code from styles to type - https://www.drupal.org/project/ckeditor_liststyle/issues/2874952": "https://www.drupal.org/files/issues/2019-01-02/ckeditor_liststyle-styles-to-type-2874952-4-do-not-test.patch"


### PR DESCRIPTION
Remove closed patch for inline entity form foud from testing content-vic [SDPAP-6611](https://digital-vic.atlassian.net/browse/SDPAP-6611) change but has drupal/core 9.2 downgrade issue.