### PR TITLE
SDPAP-5303: Navigating long menus in the CMS.

### DIFF
--- a/src/Render/Element/AdminToolbar.php
+++ b/src/Render/Element/AdminToolbar.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace Drupal\tide_core\Render\Element;
+
+use Drupal\Core\Menu\MenuTreeParameters;
+use Drupal\Core\Security\TrustedCallbackInterface;
+
+/**
+ * Define an admin toolbar.
+ *
+ * @package Drupal\tide_core\Render\Element
+ */
+class AdminToolbar implements TrustedCallbackInterface {
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function trustedCallbacks() {
+    return ['preRenderTray'];
+  }
+
+  /**
+   * Renders the toolbar's administration tray.
+   *
+   * This is a clone of admin_toolbar's
+   * admin_toolbar_prerender_toolbar_administration_tray() function, which uses
+   * setMaxDepth(5) instead of setMaxDepth(4).
+   *
+   * @param array $build
+   *   A renderable array.
+   *
+   * @return array
+   *   The updated renderable array.
+   *
+   * @see toolbar_prerender_toolbar_administration_tray()
+   * @see admin_toolbar_prerender_toolbar_administration_tray()
+   */
+  public static function preRenderTray(array $build) {
+    $element = [];
+    $menu_tree = \Drupal::service('toolbar.menu_tree');
+    $parameters = new MenuTreeParameters();
+    $parameters->setRoot('system.admin')->excludeRoot()->setMaxDepth(5)->onlyEnabledLinks();
+    $tree = $menu_tree->load(NULL, $parameters);
+    $manipulators = [
+      ['callable' => 'menu.default_tree_manipulators:checkAccess'],
+      ['callable' => 'menu.default_tree_manipulators:generateIndexAndSort'],
+      ['callable' => 'tide_core_menu_navigation_links'],
+    ];
+    $tree = $menu_tree->transform($tree, $manipulators);
+    $element['administration_menu'] = $menu_tree->build($tree);
+
+    return $element;
+  }
+
+}

--- a/tide_core.module
+++ b/tide_core.module
@@ -691,6 +691,6 @@ function tide_core_toolbar_alter(&$items) {
     [
       AdminToolbar::class,
       'preRenderTray',
-    ]
+    ],
   ];
 }

--- a/tide_core.module
+++ b/tide_core.module
@@ -22,6 +22,8 @@ use Drupal\views\ViewExecutable;
 use Drupal\workflows\Entity\Workflow;
 use Drupal\redirect\Entity\Redirect;
 use Drupal\Core\Cache\Cache;
+use Drupal\tide_core\Render\Element\AdminToolbar;
+use Drupal\Component\Utility\Html;
 
 /**
  * Implements hook_views_data().
@@ -648,4 +650,47 @@ function tide_core_admin_audit_trail_handlers() {
     'title' => t('Page'),
   ];
   return $handlers;
+}
+
+/**
+ * Adds toolbar-specific attributes to the menu link tree.
+ *
+ * @param \Drupal\Core\Menu\MenuLinkTreeElement[] $tree
+ *   The menu link tree to manipulate.
+ *
+ * @return \Drupal\Core\Menu\MenuLinkTreeElement[]
+ *   The manipulated menu link tree.
+ */
+function tide_core_menu_navigation_links(array $tree) {
+  foreach ($tree as $element) {
+    // Remove menu and taxonomy subtree.
+    if (($element->link->getPluginId() === 'entity.menu.collection') || ($element->link->getPluginId() === 'entity.taxonomy_vocabulary.collection')) {
+      unset($element->subtree);
+    }
+    if (($element->link->getPluginId() != 'entity.menu.collection')
+      && ($element->link->getPluginId() != 'entity.taxonomy_vocabulary.collection')
+      && $element->subtree) {
+      tide_core_menu_navigation_links($element->subtree);
+    }
+    $link = $element->link;
+    // Get the non-localized title to make the icon class.
+    $definition = $link->getPluginDefinition();
+    $element->options['attributes']['class'][] = 'toolbar-icon';
+    $string = strtolower(str_replace(['.', ' ', '_'], ['-', '-', '-'], $definition['id']));
+    $element->options['attributes']['class'][] = Html::cleanCssIdentifier('toolbar-icon-' . $string);
+    $element->options['attributes']['title'] = $link->getDescription();
+  }
+  return $tree;
+}
+
+/**
+ * Implements hook_toolbar_alter().
+ */
+function tide_core_toolbar_alter(&$items) {
+  $items['administration']['tray']['toolbar_administration']['#pre_render'] = [
+    [
+      AdminToolbar::class,
+      'preRenderTray',
+    ]
+  ];
 }


### PR DESCRIPTION
Jirra: https://digital-vic.atlassian.net/browse/SDPAP-5303

**Navigating long menus in the CMS**


As a CMS user I want to easily navigate through long drop-down menus in the CMS admin console to find the item I am looking for.

Background
As the CMS is growing the menu drop-downs are becoming bigger and bigger. There is currently no way of navigating through long navigation lists as items get cut off at the bottom of the screen. 

This is only an issue on two menu items:

Structure > Menus

Structure > Taxonomy

After a UX review [https://digital-vic.atlassian.net/browse/SDPA-5543 - Can't find link](https://digital-vic.atlassian.net/browse/SDPA-5543) the current solution is to:

remove the long secondary dropdowns (level 3) as they are not scalable, and

make users access the child options by clicking on the parent menu item (Menu and Taxonomy). 


The long term solution is to make these listing pages more usable via search and filter functions.

Assumptions
The chevron icons to the right of both Menus and Taxonomy are to be removed

The background colour of both Menus and Taxonomy will match the background colour of the other navigation options at the same level. 

Acceptance criteria
As a CMS approver in the CMS I can:

hover over the Structure main navigation item

click on Menus which takes me to the menus listing page

click on Taxonomy which takes me to the taxonomies listing page

I do not have any additional navigation drop-downs appear if I hover over Menus or Taxonomy

I cannot see chevron icons to the right of either Menus or Taxonomy

the background colour of Menus and Taxonomy navigation items is same colour as the other items at the same level (with no sub-items).

Solution direction
Scenario 1
[https://api.drupal.org/api/drupal/core!lib!Drupal!Core!Menu!MenuLinkTree.php/function/MenuLinkTree%3A%3Aload/8.2.x](https://api.drupal.org/api/drupal/core/!lib/!Drupal/!Core/!Menu/!MenuLinkTree.php/function/MenuLinkTree%3A%3Aload/8.2.x)

This will disable the menu tree for all items under.

Scenario 2
Implement a hook that triggers when a menu item gets created.
If an item is under the menus it will not enable it and hence it will not appear in the dropdown.

