### PR TITLE
[DDS-1349] Enable more admin_audit_trail submodules.

### DIFF
--- a/tide_core.info.yml
+++ b/tide_core.info.yml
@@ -47,6 +47,8 @@ dependencies:
   - admin_audit_trail:admin_audit_trail_media
   - admin_audit_trail:admin_audit_trail_user
   - admin_audit_trail:admin_audit_trail_workflows
+  - admin_audit_trail:admin_audit_trail_block_content
+  - admin_audit_trail:admin_audit_trail_redirect
   - fakeobjects:fakeobjects
   - fast_404:fast404
   - link_field_autocomplete_filter:link_field_autocomplete_filter


### PR DESCRIPTION
Jira - https://digital-vic.atlassian.net/browse/DDS-1348

## Changes

This PR enables two additional admin_audit_trail submodules which will audit when changes are made to redirects and blocks.