### PR TITLE
[SDPAP-5665] Add moderated content submenu to Content Menu

### DIFF
--- a/config/install/user.role.editor.yml
+++ b/config/install/user.role.editor.yml
@@ -126,7 +126,6 @@ permissions:
   - 'use text format summary_text'
   - 'view alert revisions'
   - 'view all revisions'
-  - 'view any unpublished content'
   - 'view any webform submission'
   - 'view image_gallery revisions'
   - 'view landing_page revisions'

--- a/tests/behat/features/workflow.feature
+++ b/tests/behat/features/workflow.feature
@@ -286,15 +286,6 @@ Feature: Workflow states and transitions
     Then I should see the success message "[TEST] Editor Test title has been updated."
     And I should see a "article.node--unpublished" element
 
-    # Editor send for Review.
-    Given I am logged in as a user with the Editor role
-    When I edit test "[TEST] Editor Test title"
-    Then the response status code should be 200
-    And I select "Needs Review" from "Change to"
-    And I press "Save"
-    Then I should see the success message "[TEST] Editor Test title has been updated."
-    And I should see a "article.node--unpublished" element
-
     # Approver reviews and publishes.
     Given I am logged in as a user with the Approver role
     When I edit test "[TEST] Editor Test title"
@@ -303,15 +294,6 @@ Feature: Workflow states and transitions
     And I press "Save"
     Then I should see the success message "[TEST] Editor Test title has been updated."
     And I should not see a "article.node--unpublished" element
-
-    # Editor send request to archive content.
-    Given I am logged in as a user with the Editor role
-    When I edit test "[TEST] Editor Test title"
-    Then the response status code should be 200
-    And I select "Archive pending" from "Change to"
-    And I press "Save"
-    Then I should see the success message "[TEST] Editor Test title has been updated."
-    And I should see a "article.node--unpublished" element
 
     # Approver reviews and archive.
     Given I am logged in as a user with the Approver role

--- a/tide_core.install
+++ b/tide_core.install
@@ -1560,3 +1560,12 @@ function tide_core_update_8065() {
     $config->save();
   }
 }
+
+/**
+ * Editor should not have access to redirects.
+ */
+function tide_core_update_8066() {
+  $role = 'editor';
+  $permissions = ['view any unpublished content'];
+  user_role_revoke_permissions($role, $permissions);
+}

--- a/tide_core.install
+++ b/tide_core.install
@@ -1560,12 +1560,3 @@ function tide_core_update_8065() {
     $config->save();
   }
 }
-
-/**
- * Editor should not have access to content moderation.
- */
-function tide_core_update_8066() {
-  $role = 'editor';
-  $permissions = ['view any unpublished content'];
-  user_role_revoke_permissions($role, $permissions);
-}

--- a/tide_core.install
+++ b/tide_core.install
@@ -1562,7 +1562,7 @@ function tide_core_update_8065() {
 }
 
 /**
- * Editor should not have access to redirects.
+ * Editor should not have access to content moderation.
  */
 function tide_core_update_8066() {
   $role = 'editor';

--- a/tide_core.install
+++ b/tide_core.install
@@ -1560,3 +1560,12 @@ function tide_core_update_8065() {
     $config->save();
   }
 }
+
+/**
+ * Editor should not have access to content moderation.
+ */
+function tide_core_update_8066() {
+  $role = 'editor';
+  $permissions = ['view any unpublished content'];
+  user_role_revoke_permissions($role, $permissions);
+}


### PR DESCRIPTION
<!--
Please follow these rules:
1. SUBJECT: use format [SDPA-123] Verb in past tense with dot at the end.
   - This subject will be used as a commit message after PR is merged.
   - Verbs are usually one of these: Updated, Refactored, Removed, Changed, Added.
   - If there is no ticket - do not put [NOTICKET].

2. BODY: fill-in the template below

3. LABEL: Assign 'Needs review' label as soon as you ready to have this reviewed.

4. ASSIGNEE: Assign at least 2 reviewers.     

5. SLACK: Post a link to this PR to #developers channel.

No need to remove these lines - they are comments.
-->

**JIRA issue:** https://digital-engagement.atlassian.net/browse/SDPAP-5665

### Changed

1. Based on defect found [https://digital-vic.atlassian.net/browse/SDPAP-5665?focusedCommentId=141936], update the permissions for editor role to remove access for content moderation section.

### Screenshots

<!--
Provide as many screenshots as required to make reviewers understand what was changed.
-->
**Administrator**
![Screen Shot 2022-11-04 at 4 28 44 PM](https://user-images.githubusercontent.com/23239224/199928150-824162f0-7711-408d-8eb1-c0373ae3fa9d.png)

**Approver**
![Screen Shot 2022-11-04 at 4 31 08 PM](https://user-images.githubusercontent.com/23239224/199928263-e151a6ae-1127-4cbe-8a75-e964c397d5a8.png)

**Editor**
![Screen Shot 2022-11-04 at 4 29 11 PM](https://user-images.githubusercontent.com/23239224/199928333-0388d477-835c-4430-a3cb-491206e7ad35.png)
