### PR TITLE
SDPAP-7127 Fixed undefined property captured for menus

### DIFF
--- a/tide_core.module
+++ b/tide_core.module
@@ -705,8 +705,8 @@ function tide_core_admin_audit_trail_handlers() {
 function tide_core_menu_navigation_links(array $tree) {
   foreach ($tree as $element) {
     // Remove menu and taxonomy subtree.
-    if (($element->link->getPluginId() === 'entity.menu.collection') || ($element->link->getPluginId() === 'entity.taxonomy_vocabulary.collection')) {
-      unset($element->subtree);
+    if (($element->link->getPluginId() === 'entity.menu.collection' || $element->link->getPluginId() === 'entity.taxonomy_vocabulary.collection') && isset($element->subtree)) {
+      $element->subtree = [];
     }
     if (($element->link->getPluginId() != 'entity.menu.collection')
       && ($element->link->getPluginId() != 'entity.taxonomy_vocabulary.collection')


### PR DESCRIPTION
### Jira
https://digital-vic.atlassian.net/browse/SDPAP-7127

### Problem/Motivation
There are 2 error messages in the local and develop(could be found in the dblog)  environments, which may relate to [https://digital-vic.atlassian.net/browse/SDPAP-5303](https://digital-vic.atlassian.net/browse/SDPAP-5303) 

https://develop.content.vic.gov.au/admin/reports/dblog/event/3

![7165eba3-55ff-4a59-bfb7-06fcaf3e1674](https://user-images.githubusercontent.com/23239224/213152053-b8ae11ed-449f-4d06-8f5d-f2084ee5d833.png)

### Fix
1. Added additional conditions in tide_core_menu_navigation_links under tide_core.module file and revised the way of unsetting subtree menu for Taxonomy and Menu Navigation by emptying $element->subtree instead of unsetting it which will totally removed the array variable from the menu tree.

### Related PRs

### Screenshots
![Screen Shot 2023-01-18 at 6 51 17 PM](https://user-images.githubusercontent.com/23239224/213153824-2b87eb5e-2bed-4f82-ac42-abbd55bbea60.png)
![Screen Shot 2023-01-18 at 6 53 46 PM](https://user-images.githubusercontent.com/23239224/213153833-78771817-2b66-4a2b-b971-bcdd442ccfac.png)

