### PR TITLE
[SDPAP-7077] Related link mandatory and help text.

### DIFF
--- a/config/install/field.field.paragraph.related_links.field_paragraph_link.yml
+++ b/config/install/field.field.paragraph.related_links.field_paragraph_link.yml
@@ -11,12 +11,12 @@ field_name: field_paragraph_link
 entity_type: paragraph
 bundle: related_links
 label: Link
-description: ''
+description: 'Add a descriptive title for your link. This is what displays on the live website.'
 required: false
 translatable: true
 default_value: {  }
 default_value_callback: ''
 settings:
   link_type: 17
-  title: 1
+  title: 2
 field_type: link

--- a/tide_core.install
+++ b/tide_core.install
@@ -1687,3 +1687,16 @@ function tide_core_update_8072() {
     $role->save();
   }
 }
+
+/**
+ * Make Related link field mandatory and adds help text.
+ */
+function tide_core_update_8073() {
+  $config_factory = \Drupal::configFactory();
+  $config = $config_factory->getEditable('field.field.paragraph.related_links.field_paragraph_link');
+  if ($config) {
+    $config->set('description', 'Add a descriptive title for your link. This is what displays on the live website.');
+    $config->set('settings.title', 2);
+    $config->save();
+  }
+}

--- a/tide_core.install
+++ b/tide_core.install
@@ -1692,16 +1692,11 @@ function tide_core_update_8072() {
  * Make Related link field mandatory and adds help text.
  */
 function tide_core_update_8073() {
-  module_load_include('inc', 'tide_core', 'includes/helpers');
-  $config_location = [\Drupal::service('extension.list.module')->getPath('tide_core') . '/config/install'];
-  $config_id = 'field.field.paragraph.related_links.field_paragraph_link';
-  $link_config = \Drupal::configFactory()->getEditable($config_id);
-  $link_config_read = _tide_read_config($config_id, $config_location, FALSE);
-  $link_description = $link_config_read['description'];
-  $systems = $link_config_read['settings']['title'];
-  if ($link_config) {
-    $link_config->set('description', $link_description);
-    $link_config->set('settings.title', $systems);
-    $link_config->save();
+  $config_factory = \Drupal::configFactory();
+  $config = $config_factory->getEditable('field.field.paragraph.related_links.field_paragraph_link');
+  if ($config) {
+    $config->set('description', 'Add a descriptive title for your link. This is what displays on the live website.');
+    $config->set('settings.title', 2);
+    $config->save();
   }
 }

--- a/tide_core.install
+++ b/tide_core.install
@@ -1702,6 +1702,6 @@ function tide_core_update_8073() {
   if ($link_config) {
     $link_config->set('description', $link_description);
     $link_config->set('settings.title', $systems);
-
+    $link_config->save();
   }
 }

--- a/tide_core.install
+++ b/tide_core.install
@@ -1692,11 +1692,16 @@ function tide_core_update_8072() {
  * Make Related link field mandatory and adds help text.
  */
 function tide_core_update_8073() {
-  $config_factory = \Drupal::configFactory();
-  $config = $config_factory->getEditable('field.field.paragraph.related_links.field_paragraph_link');
-  if ($config) {
-    $config->set('description', 'Add a descriptive title for your link. This is what displays on the live website.');
-    $config->set('settings.title', 2);
-    $config->save();
+  module_load_include('inc', 'tide_core', 'includes/helpers');
+  $config_location = [\Drupal::service('extension.list.module')->getPath('tide_core') . '/config/install'];
+  $config_id = 'field.field.paragraph.related_links.field_paragraph_link';
+  $link_config = \Drupal::configFactory()->getEditable($config_id);
+  $link_config_read = _tide_read_config($config_id, $config_location, FALSE);
+  $link_description = $link_config_read['description'];
+  $systems = $link_config_read['settings']['title'];
+  if ($link_config) {
+    $link_config->set('description', $link_description);
+    $link_config->set('settings.title', $systems);
+
   }
 }

--- a/tide_core.module
+++ b/tide_core.module
@@ -705,8 +705,8 @@ function tide_core_admin_audit_trail_handlers() {
 function tide_core_menu_navigation_links(array $tree) {
   foreach ($tree as $element) {
     // Remove menu and taxonomy subtree.
-    if (($element->link->getPluginId() === 'entity.menu.collection') || ($element->link->getPluginId() === 'entity.taxonomy_vocabulary.collection')) {
-      unset($element->subtree);
+    if (($element->link->getPluginId() === 'entity.menu.collection' || $element->link->getPluginId() === 'entity.taxonomy_vocabulary.collection') && isset($element->subtree)) {
+      $element->subtree = [];
     }
     if (($element->link->getPluginId() != 'entity.menu.collection')
       && ($element->link->getPluginId() != 'entity.taxonomy_vocabulary.collection')


### PR DESCRIPTION
### Jira
https://digital-vic.atlassian.net/browse/SDPAP-7077

### Problem/Motivation
In this component, the URL field is mandatory. But the Link text field is currently not mandatory. The Link text field needs to be mandatory in order for the link to display.
If a CMS user fills the URL field but not the Link text field, they are able to save the node/page OK but on the front end, if there is no content in the Link text field, no link will display.

### Fix
1. Made 'Related link' mandatory and added help text.

### Related PRs
BE: https://github.com/dpc-sdp/content-reference-sdp-vic-gov-au/pull/202 | https://nginx-php.pr-202.content-reference-sdp-vic-gov-au.sdp4.sdp.vic.gov.au/

### Screenshots
Before:
![image](https://user-images.githubusercontent.com/67810118/215376448-205a6c54-ac14-4c80-9aff-9a19913c5349.png)

After:
![Screenshot 2023-01-30 at 11 19 30 am](https://user-images.githubusercontent.com/67810118/215376724-4f2de445-5f73-41d2-bc05-63aa6ecc95b5.png)


### TODO
