### PR TITLE
Updated plugin implementation of entity_reference paragraphs widget.

### DIFF
--- a/src/Plugin/Field/FieldWidget/PresetParagraphsWidget.php
+++ b/src/Plugin/Field/FieldWidget/PresetParagraphsWidget.php
@@ -210,7 +210,7 @@ class PresetParagraphsWidget extends ParagraphsWidget {
       '#required' => $this->fieldDefinition->isRequired(),
       '#field_name' => $field_name,
       '#cardinality' => $cardinality,
-      '#max_delta' => $max - 1,
+      '#max_delta' => is_int($max) ? ($max - 1) : '',
     ];
 
     if ($this->realItemCount > 0) {


### PR DESCRIPTION
### Jira
https://digital-vic.atlassian.net/browse/SRM-664

### Problem/Motivation
The media: buying for vic content type uses a link paragraph type which has a widget type set to PresetParagraphsWidget. tide_core has a custom plugin for this and [this place](https://github.com/dpc-sdp/tide_core/blob/develop/src/Plugin/Field/FieldWidget/PresetParagraphsWidget.php#L104) gets the preset_number from field config [here](https://github.com/dpc-sdp/content-vic-gov-au/blob/develop/config/sync/core.entity_form_display.node.media_buying_for_vic.default.yml#L338) and before it used to return a numeric value instead of empty string. With all the changes, its now returns exactly an empty string and which triggers the above error [in this line](https://github.com/dpc-sdp/tide_core/blob/develop/src/Plugin/Field/FieldWidget/PresetParagraphsWidget.php#L213)

### Fix
Change how sets up the #max_delta value, only do -1 when the $max value is a int else sets it as an empty string.

### Related PRs

### Screenshots

### TODO
