### PR TITLE
[SDPAP-7334] Alert for CMS users - Severity levels

### DIFF
--- a/modules/tide_site_alert/css/site_alert.css
+++ b/modules/tide_site_alert/css/site_alert.css
@@ -32,14 +32,29 @@
 .site-alert .severity-low,
 .site-alert .severity-medium,
 .site-alert .severity-high {
-  color: #000000;
-  border: 1px solid #cccccc;
-  background: #f3eaac;
   position: relative;
   margin-bottom: 1.5em;
   background-repeat: no-repeat;
   background-position: 1% 50%;
   background-size: 30px 30px;
+}
+
+.site-alert .severity-low {
+  color: #31708f;
+  background-color: #d9edf7;
+  border: 1px solid #bce8f1;
+}
+
+.site-alert .severity-medium {
+  color: #8a6d3b;
+  background-color: #f3eaac;
+  border: 1px solid #faebcc;
+}
+
+.site-alert .severity-high {
+  color: #a94442;
+  background-color: #f2dede;
+  border: 1px solid #ebccd1;
 }
 
 .site-alert .site-alert__dismiss {

--- a/modules/tide_site_alert/tide_site_alert.module
+++ b/modules/tide_site_alert/tide_site_alert.module
@@ -47,8 +47,6 @@ function tide_site_alert_form_site_alert_form_alter(&$form, FormStateInterface $
       'effect'   => 'fade',
     ],
   ];
-  $form['severity']['#access'] = FALSE;
-  $form['severity']['widget']['#default_value'] = 'medium';
   $form['label']['widget'][0]['value']['#prefix']
     = '<div id="suggested-labels">';
   $form['label']['widget'][0]['value']['#suffix'] = '</div>';


### PR DESCRIPTION
### Jira
https://digital-vic.atlassian.net/browse/SDPAP-7334

### Problem/Motivation
The support team would like to use of the severity fields in the alert module. 

### Fix
Red banner at the top of the screen below the drupal menu (Severity = High)
Yellow banner at the top of the screen below the drupal menu (Severity = Medium)
Blue banner at the top of the screen below the drupal menu (Severity = Low)

### Related links

https://nginx-php.pr-218.content-reference-sdp-vic-gov-au.sdp4.sdp.vic.gov.au/

### Screenshots
![CleanShot 2023-02-21 at 13 35 36](https://user-images.githubusercontent.com/8788145/220233080-55f90c27-9264-4406-b18f-c40521fccda4.jpg)
