### PR TITLE
Commented updated hook.

### DIFF
--- a/tide_core.install
+++ b/tide_core.install
@@ -1555,8 +1555,7 @@ function tide_core_update_8064() {
 }
 
 /**
- * tide_core_update_8065 is removed.
- * See ticket SDPAP-7108 for more details.
+ * See ticket SDPAP-7108, tide_core_update_8065 is removed.
  */
 
 /**

--- a/tide_core.install
+++ b/tide_core.install
@@ -1558,12 +1558,17 @@ function tide_core_update_8064() {
  * Prevent new entity reference creation.
  */
 function tide_core_update_8065() {
-  $config_factory = \Drupal::configFactory();
-  $config = $config_factory->getEditable('field.field.block_content.media_gallery.field_topic');
-  if ($config) {
-    $config->set('settings.handler_settings.auto_create', FALSE);
-    $config->save();
-  }
+  /*
+    This should not be here as this field is provided by tide_landing_page.
+    It creates issues for the module that are depending on tide_core but
+    does not depends on tide_landing_page.
+    $config_factory = \Drupal::configFactory();
+    $config = $config_factory->getEditable('field.field.block_content.media_gallery.field_topic');
+    if ($config) {
+      $config->set('settings.handler_settings.auto_create', FALSE);
+      $config->save();
+    }
+  */
 }
 
 /**

--- a/tide_core.install
+++ b/tide_core.install
@@ -1555,21 +1555,9 @@ function tide_core_update_8064() {
 }
 
 /**
- * Prevent new entity reference creation.
+ * tide_core_update_8065 is removed.
+ * See ticket SDPAP-7108 for more details.
  */
-function tide_core_update_8065() {
-  /*
-  This should not be here as this field is provided by tide_landing_page.
-  It creates issues for the module that are depending on tide_core but
-  does not depends on tide_landing_page.
-  $config_factory = \Drupal::configFactory();
-  $config = $config_factory->getEditable('field.field.block_content.media_gallery.field_topic');
-  if ($config) {
-  $config->set('settings.handler_settings.auto_create', FALSE);
-  $config->save();
-  }
-   */
-}
 
 /**
  * Install field permission module.

--- a/tide_core.install
+++ b/tide_core.install
@@ -1559,16 +1559,16 @@ function tide_core_update_8064() {
  */
 function tide_core_update_8065() {
   /*
-    This should not be here as this field is provided by tide_landing_page.
-    It creates issues for the module that are depending on tide_core but
-    does not depends on tide_landing_page.
-    $config_factory = \Drupal::configFactory();
-    $config = $config_factory->getEditable('field.field.block_content.media_gallery.field_topic');
-    if ($config) {
-      $config->set('settings.handler_settings.auto_create', FALSE);
-      $config->save();
-    }
-  */
+  This should not be here as this field is provided by tide_landing_page.
+  It creates issues for the module that are depending on tide_core but
+  does not depends on tide_landing_page.
+  $config_factory = \Drupal::configFactory();
+  $config = $config_factory->getEditable('field.field.block_content.media_gallery.field_topic');
+  if ($config) {
+  $config->set('settings.handler_settings.auto_create', FALSE);
+  $config->save();
+  }
+   */
 }
 
 /**


### PR DESCRIPTION
### Jira
https://digital-vic.atlassian.net/browse/SDPAP-7108

### Problem/Motivation
1. It causes issues for tide_site as tide_site not dependant on tide_landing_page  and creates a garbage field as the field is not provided by tide_core. This hook should have been added in tide_landing_page
2. It causes issues for tide_landing_page as well, cause tide_landing_page already has this field in the active config and then tide_core tries to add it again while running this hook and creates conflicts

### Fix
1. Commenting out the hook so that it does not run this on other modules where tide_core is added as a dependency.

### Related PRs

### Screenshots

### TODO
