### PR TITLE
[SDPAP-7401]delete link task for schedules update

### DIFF
--- a/tide_core.links.task.yml
+++ b/tide_core.links.task.yml
@@ -1,4 +1,0 @@
-tide_core.scheduled_update:
-  title: Scheduled updates
-  route_name: entity.scheduled_transition.collection
-  base_route: system.admin_content


### PR DESCRIPTION
### Jira
https://digital-vic.atlassian.net/browse/SDPAP-7401
### Problem/Motivation
Currently content Navigation Bar has two options for Scheduling Updates not only content-vic but content-reference, content-vicpol,etc. Both schedule transition and schedule update are linking to schedule transition. 
We want to remove 'Schedule update' and keep 'Schedule transition' instead
 BE LINK: https://nginx-php.pr-233.content-reference-sdp-vic-gov-au.sdp4.sdp.vic.gov.au/admin/content
### Fix
By deleting tide_core.links.task.yml
### Related PRs

### Screenshots
![Screenshot 2023-03-14 at 12 15 52 pm](https://user-images.githubusercontent.com/47239456/224867255-e216dbe0-706d-41c4-babd-37bd27f33e84.png)

### TODO
