### PR TITLE
release/3.2.4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -84,7 +84,8 @@
         "drupal/field_permissions": "^1.2",
         "lesstif/php-jira-rest-client": "2.6.0",
         "drupal/jira_rest": "^4.0@beta",
-        "drupal/site_alert": "1.x-dev@dev"
+        "drupal/site_alert": "1.x-dev@dev",
+        "lcobucci/clock": "3.0.0"
     },
     "repositories": {
         "drupal": {


### PR DESCRIPTION
### Changes
* Fix `lcobucci/clock` to 3.0.0 because of the issue
  * lcobucci/clock 3.1.0 requires php ~8.2.0 -> your php version (8.1.15) does not satisfy that requirement.
