### PR TITLE
Release/3.2.5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -56,7 +56,7 @@
         "drupal/role_delegation": "^1.0-alpha1",
         "drupal/seckit": "^1.1",
         "drupal/simple_oauth": "^5.2",
-        "drupal/simple_sitemap": "^3.0",
+        "drupal/simple_sitemap": "^4.0",
         "drupal/smart_trim": "^1.1",
         "drupal/smtp": "^1.0@RC",
         "drupal/stage_file_proxy": "^1.1",


### PR DESCRIPTION
bumps simple_sitemap to 4.x preparing for the compatible with D10.
