### PR TITLE
Remove noncanonical repository(entity_embed)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
         "drupal/editor_advanced_link": "^2.0",
         "drupal/entity_browser": "^2.6",
         "drupal/entity_reference_revisions": "^1.9",
-        "drupal/entity_embed": "dev-3272732-drupal-10- as 1.3.0",
+        "drupal/entity_embed": "dev-1.x",
         "drupal/environment_indicator": "^4.0",
         "drupal/fast_404": "^2.0",
         "drupal/field_group": "^3.1",
@@ -86,12 +86,7 @@
     "repositories": {
         "drupal": {
             "type": "composer",
-            "url": "https://packages.drupal.org/8",
-            "canonical": false
-        },
-        "drupal/entity_embed": {
-            "type": "git",
-            "url": "https://git.drupalcode.org/issue/entity_embed-3272732.git"
+            "url": "https://packages.drupal.org/8"
         },
         "ckeditor.autogrow": {
             "_webform": true,
@@ -247,7 +242,8 @@
                 "[PHP 8.1] Deprecated function: strcasecmp(): Passing null to parameter #1 ($string1) of type string is deprecated - https://www.drupal.org/project/ckeditor_config/issues/3330938#comment-14852534": "https://www.drupal.org/files/issues/2023-01-04/php-8.1-deprecated-function-warnings-3330938-3.patch"
             },
             "drupal/entity_embed": {
-                "More defensive handling of data-entity-embed-display-settings - https://www.drupal.org/project/entity_embed/issues/3010942": "https://www.drupal.org/files/issues/2019-12-11/3077225-10.reduce-invalid-config-logs.patch"
+                "More defensive handling of data-entity-embed-display-settings - https://www.drupal.org/project/entity_embed/issues/3010942": "https://www.drupal.org/files/issues/2019-12-11/3077225-10.reduce-invalid-config-logs.patch",
+                "CKEditor5 support initial commit - https://www.drupal.org/project/entity_embed/issues/3272732#comment-15037680": "https://www.drupal.org/files/issues/2023-05-05/entity_embed-3272732-80.patch"
             },
             "drupal/token": {
                 "Summary token not fully handled in fields": "https://www.drupal.org/files/issues/tokens.body-with-summary.patch"


### PR DESCRIPTION
### Problem/Motivation
Using a noncanonical repository (fork) that originates from a Drupal ticket for issue resolution can potentially lead to a broken composer. This may happen if the changes are merged into the main branch and the forked repository is subsequently closed and deleted.
