### PR TITLE
Bump metatag to 2.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -38,7 +38,7 @@
         "drupal/m4032404": "^1.0-alpha4",
         "drupal/maxlength": "^1.0-beta2",
         "drupal/media_entity_audio": "^3.0",
-        "drupal/metatag": "^1.7",
+        "drupal/metatag": "^2.0@RC",
         "drupal/override_node_options": "^2.4",
         "drupal/paragraphs": "^1.5",
         "drupal/password_policy": "dev-3.x",


### PR DESCRIPTION
### release/3.2.10

Bump metatag module to 2.x

