### PR TITLE
[DDS-1474] Fix bootstrap system corruption under high traffic

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -236,7 +236,8 @@
                 "Claro preprocessing of field multiple value form table header cell removes potential changes by others - https://www.drupal.org/project/drupal/issues/3099026#comment-14940311": "https://www.drupal.org/files/issues/2023-02-24/3099026-51.patch",
                 "Form Required Class Missing from Claro - https://www.drupal.org/project/drupal/issues/3160987#comment-14609681": "https://www.drupal.org/files/issues/2022-07-17/3160987-10.patch",
                 "DateTimeComputed tries to compute from an empty value - https://www.drupal.org/project/drupal/issues/3052608#comment-14666671": "https://www.drupal.org/files/issues/2022-08-25/DateTimeComputed-tries-to-compute-from-an-empty-value-3052608-16.patch",
-                "Querying with NULL values results in warning mb_strtolower() - https://www.drupal.org/project/drupal/issues/3302838": "https://www.drupal.org/files/issues/2022-08-23/3302838-13.patch"
+                "Querying with NULL values results in warning mb_strtolower() - https://www.drupal.org/project/drupal/issues/3302838": "https://www.drupal.org/files/issues/2022-08-23/3302838-13.patch",
+                "ModuleHandler skips all hook implementations when invoked before the module files have been loaded - https://www.drupal.org/project/drupal/issues/3207813": "https://www.drupal.org/files/issues/2022-06-21/3207813-15.patch"
             },
             "drupal/ckeditor_config": {
                 "[PHP 8.1] Deprecated function: strcasecmp(): Passing null to parameter #1 ($string1) of type string is deprecated - https://www.drupal.org/project/ckeditor_config/issues/3330938#comment-14852534": "https://www.drupal.org/files/issues/2023-01-04/php-8.1-deprecated-function-warnings-3330938-3.patch"


### PR DESCRIPTION
### Jira

https://digital-vic.atlassian.net/browse/DDS-1474

### Problem/Motivation

https://www.drupal.org/project/drupal/issues/3207813

Due to the way the Shield module behaves when used in combination with the Key module, corruption of the bootstrap system can occur as Shield attempts to use entityTypeManager too early in the request lifecycle before module files are loaded. This can cause the module_implements cache to be populated with missing data and as a result, hooks such as hook_entity_type_alter are no longer effective.

### Fix

Patch ModuleHandler to load all module files if invoked from an http_middleware service while the `module_implements` cache is not yet populated.

### Related PRs

### Screenshots

### TODO
