### PR TITLE
Locked editor_advanced_link module to a working version with ck5.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
         "drupal/ckeditor_templates": "1.x-dev",
         "drupal/ctools": "^3.11",
         "drupal/diff": "^1.0-RC2",
-        "drupal/editor_advanced_link": "^2.0",
+        "drupal/editor_advanced_link": "2.1.1",
         "drupal/entity_browser": "^2.6",
         "drupal/entity_reference_revisions": "^1.9",
         "drupal/entity_embed": "dev-1.x",


### PR DESCRIPTION
### Jira

### Problem/Motivation
https://www.drupal.org/project/editor_advanced_link/issues/3370300
### Fix
Locking the editor_advanced_link module to last working version with ck5.
### Related PRs

### Screenshots
![image](https://github.com/dpc-sdp/tide_core/assets/20810541/9156f507-2adb-485e-bbe7-0d8e2766ae6a)

### TODO
