### PR TITLE
fix: editor_advanced_link errors

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
         "drupal/ckeditor_templates": "1.x-dev",
         "drupal/ctools": "^3.11",
         "drupal/diff": "^1.0-RC2",
-        "drupal/editor_advanced_link": "2.1.1",
+        "drupal/editor_advanced_link": "^2.2.3",
         "drupal/entity_browser": "^2.6",
         "drupal/entity_reference_revisions": "^1.9",
         "drupal/entity_embed": "dev-1.x",


### PR DESCRIPTION
### Jira
no jira ticket

### Problem/Motivation
'Unsafe-eval' required after update to 2.2.1
https://www.drupal.org/project/editor_advanced_link/issues/3370300

