### PR TITLE
[SDPAP-8093] remove deprecated modules before d10 update

### DIFF
--- a/tide_core.info.yml
+++ b/tide_core.info.yml
@@ -15,7 +15,6 @@ dependencies:
   - drupal:block
   - drupal:block_content
   - drupal:content_moderation
-  - drupal:ckeditor
   - drupal:ckeditor5
   - drupal:datetime_range
   - drupal:dynamic_page_cache
@@ -32,7 +31,6 @@ dependencies:
   - drupal:user
   - drupal:views
   - drupal:workflows
-  - drupal:hal
   - drupal:token
   - editor_advanced_link:editor_advanced_link
   - entity_browser:entity_browser

--- a/tide_core.install
+++ b/tide_core.install
@@ -1921,7 +1921,7 @@ function tide_core_update_8090() {
 function tide_core_update_8091() {
   $modules = ['ckeditor', 'wysiwyg_template_core', 'color', 'hal', 'tide_spell_checker'];
   foreach ($modules as $module) {
-    // Check if queue_mail is both installed and enabled.
+    // Check if module is both installed and enabled.
     if (\Drupal::moduleHandler()->moduleExists($module)) {
       // If exists, uninstall module.
       \Drupal::service('module_installer')->uninstall([$module]);

--- a/tide_core.install
+++ b/tide_core.install
@@ -1914,3 +1914,17 @@ function tide_core_update_8090() {
   $config_storage = \Drupal::service('config.storage');
   $config_storage->write($view, $source->read($view));
 }
+
+/**
+ * Remove deprecated modules before d10 upgrade.
+ */
+function tide_core_update_8091() {
+  $modules = ['ckeditor', 'wysiwyg_template_core', 'color', 'hal', 'tide_spell_checker'];
+  foreach ($modules as $module) {
+    // Check if queue_mail is both installed and enabled.
+    if (\Drupal::moduleHandler()->moduleExists($module)) {
+      // If exists, uninstall module.
+      \Drupal::service('module_installer')->uninstall([$module]);
+    }
+  }
+}

--- a/tide_core.install
+++ b/tide_core.install
@@ -1919,7 +1919,13 @@ function tide_core_update_8090() {
  * Remove deprecated modules before d10 upgrade.
  */
 function tide_core_update_8091() {
-  $modules = ['ckeditor', 'wysiwyg_template_core', 'color', 'hal', 'tide_spell_checker'];
+  $modules = [
+    'ckeditor', 
+    'wysiwyg_template_core', 
+    'color', 
+    'hal', 
+    'tide_spell_checker',
+  ];
   foreach ($modules as $module) {
     // Check if module is both installed and enabled.
     if (\Drupal::moduleHandler()->moduleExists($module)) {

--- a/tide_core.install
+++ b/tide_core.install
@@ -1920,10 +1920,10 @@ function tide_core_update_8090() {
  */
 function tide_core_update_8091() {
   $modules = [
-    'ckeditor', 
-    'wysiwyg_template_core', 
-    'color', 
-    'hal', 
+    'ckeditor',
+    'wysiwyg_template_core',
+    'color',
+    'hal',
     'tide_spell_checker',
   ];
   foreach ($modules as $module) {


### PR DESCRIPTION
### Jira
https://digital-vic.atlassian.net/browse/SDPAP-8093

### Problem/Motivation
Some of the module was deprecated in Drupal 9.4 and the code package reference is removed from Drupal 10. So those modules needs to be uninstalled first from SDP projects before installing the Drupal 10

### Fix
1. Removed Deprecated modules in 9.4 and added update hook to clean it from all existing projects.
2. 
### Related PRs

### Screenshots

### TODO
