### PR TITLE
[SDPAP-8299] Added null check for moderation state.

### DIFF
--- a/tide_core.module
+++ b/tide_core.module
@@ -477,7 +477,7 @@ function tide_core_form_revision_overview_form_alter(&$form, FormStateInterface 
  *   The form state.
  */
 function _tide_core_node_edit_form_log_message_validate(array &$form, FormStateInterface $form_state) {
-  if (!$form['revision_log']['#access']) {
+  if (!$form['revision_log']['#access'] || $form_state->getValue('moderation_state') === NULL) {
     return;
   }
   $moderation_state = reset($form_state->getValue('moderation_state'));


### PR DESCRIPTION
### Jira
https://digital-vic.atlassian.net/browse/SDPAP-8299
### Problem/Motivation
<img width="1131" alt="Screenshot 2023-09-07 at 4 22 57 pm" src="https://github.com/dpc-sdp/tide_core/assets/20810541/36009969-0ef0-4e51-9e8c-d291a9068507">

### Fix
Null check for moderation state to avoid this kind behaviour for content types that does not have any moderation state.
### Related PRs

### Screenshots

### TODO
