### PR TITLE
[SDPAP-8087] Use GET to allow AJAX request

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -284,7 +284,7 @@
                 "3253423: Warnings are skipped for valid users - https://www.drupal.org/project/user_expire/issues/3253423": "https://www.drupal.org/files/issues/2021-12-08/3253423-2-test-for-non-existent-account.patch"
             },
             "drupal/site_alert": {
-                "Add ability to dismiss alert - https://www.drupal.org/project/site_alert/issues/3156557#comment-14930684": "https://www.drupal.org/files/issues/2023-02-19/3156557-67.patch"
+                "Use HTTP GET to allow caching of AJAX request-3160200/Add ability to dismiss alert-3156557": "https://git.drupalcode.org/project/site_alert/-/merge_requests/3.patch"
             },
             "drupal/ckeditor_templates": {
                 "CKEditor 5 support for Content Templates - https://www.drupal.org/project/ckeditor_templates/issues/3273358#comment-14963779": "./patches/ckeditor_templates/ckeditor_templates_4.patch"


### PR DESCRIPTION
### Jira
https://digital-vic.atlassian.net/browse/SDPAP-8087

### Problem/Motivation
The site_alert js is making a POST request to the {{ajax/site_alert}}resource every 5 seconds.

This leads to a significant number of requests being made to the CMS that cannot be cached.

### Fix
Use HTTP GET to allow caching of AJAX request

### Related PRs
https://www.drupal.org/project/site_alert/issues/3160200#comment-15217710

### Screenshots
![CleanShot 2023-09-11 at 13 52 27](https://github.com/dpc-sdp/tide_core/assets/8788145/9c04a19a-00f6-4db8-9ebb-49e826207940)

The router responsible for handling `ajax/site_alert` requests has already cached the response.
https://git.drupalcode.org/issue/site_alert-3160200/-/blob/3160200-use-http-get/src/Controller/SiteAlertController.php#L126
