### PR TITLE
[SDPAP-8260] Increase character limit of URLs

### DIFF
--- a/config/optional/pathauto.settings.yml
+++ b/config/optional/pathauto.settings.yml
@@ -35,7 +35,7 @@ punctuation:
   back_slash: 0
 verbose: false
 separator: '-'
-max_length: 100
+max_length: 255
 max_component_length: 100
 transliterate: true
 reduce_ascii: false

--- a/tide_core.install
+++ b/tide_core.install
@@ -1975,3 +1975,12 @@ function tide_core_update_8095() {
       ->save();
   }
 }
+
+/**
+ * Increase character limit of URLs.
+ */
+function tide_core_update_8096() {
+  $config = \Drupal::configFactory()->getEditable('pathauto.settings');
+  $config->set('max_length', 255);
+  $config->save();
+}


### PR DESCRIPTION
### Jira
https://digital-vic.atlassian.net/browse/SDPAP-8260

### Changes
1. Change the max_length of pathauto.settings.yml to 255 characters
2. Add an update hook to implement the change.
