### PR TITLE
Update requirements to remove broken patch

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -221,7 +221,7 @@
     "extra": {
         "patches": {
             "drupal/admin_audit_trail": {
-                "Add an option to allow logging in CLI - https://www.drupal.org/project/admin_audit_trail/issues/3263615#comment-14405529": "https://www.drupal.org/files/issues/2022-02-10/3263615-admin_audit_trail-option_for_cli-3.patch",
+                "Add an option to allow logging in CLI - https://www.drupal.org/project/admin_audit_trail/issues/3263615#comment-14405529": "https://www.drupal.org/files/issues/2022-02-10/3263615-admin_audit_trail-option_for_cli-3.patch"
             },
             "drupal/core": {
                 "Contextual links should not be added inside another link - https://www.drupal.org/project/drupal/issues/2898875#comment-14018213": "https://www.drupal.org/files/issues/2021-03-03/contextual_links_should-2898875-16.patch",

--- a/composer.json
+++ b/composer.json
@@ -222,7 +222,6 @@
         "patches": {
             "drupal/admin_audit_trail": {
                 "Add an option to allow logging in CLI - https://www.drupal.org/project/admin_audit_trail/issues/3263615#comment-14405529": "https://www.drupal.org/files/issues/2022-02-10/3263615-admin_audit_trail-option_for_cli-3.patch",
-                "Latest Release Breaks Pagination - https://www.drupal.org/project/admin_audit_trail/issues/3316835": "https://git.drupalcode.org/project/admin_audit_trail/-/merge_requests/9.diff"
             },
             "drupal/core": {
                 "Contextual links should not be added inside another link - https://www.drupal.org/project/drupal/issues/2898875#comment-14018213": "https://www.drupal.org/files/issues/2021-03-03/contextual_links_should-2898875-16.patch",


### PR DESCRIPTION
A build over in tide_search (https://github.com/dpc-sdp/tide_search/pull/58) has discovered an issue with the patch here, so it should be removed since it's now in release.