### PR TITLE
[SDPAP-8367] Changes CMS support dropdown

### DIFF
--- a/modules/tide_cms_support/tide_cms_support.links.menu.yml
+++ b/modules/tide_cms_support/tide_cms_support.links.menu.yml
@@ -1,54 +1,9 @@
 tide_cms_support.cms_guides:
-  title: 'CMS Support'
+  title: 'Help'
   description: 'Access our content guides, find out where you can get further content support and training, and keep up to date by reading our latest CMS update release notes.'
   parent: 'system.admin'
-  url: https://www.singledigitalpresence.vic.gov.au/content-cms-guides
+  url: https://digital-vic.atlassian.net/servicedesk/customer/portal/14/article/2030338745
   weight: 100
-  options:
-    attributes:
-      target: _blank
-tide_cms_support.working_in_the_cms:
-  title: 'Working in the CMS'
-  description: 'Everything you need to know about working in the CMS throughout the content lifecycle – drafting, scheduling, publishing, archiving and more.'
-  parent: 'tide_cms_support.cms_guides'
-  url: https://www.singledigitalpresence.vic.gov.au/working-in-the-cms
-  weight: -50
-  options:
-    attributes:
-      target: _blank
-tide_cms_support.cms_content_templates:
-  title: 'Content templates'
-  description: 'How to use our content page templates or create specific types of content.'
-  parent: 'tide_cms_support.cms_guides'
-  url: https://www.singledigitalpresence.vic.gov.au/content-types-and-templates
-  weight: -40
-  options:
-    attributes:
-      target: _blank
-tide_cms_support.cms_components:
-  title: 'CMS components'
-  description: 'How and when to use the various components and features available for content pages in our content management system.'
-  parent: 'tide_cms_support.cms_guides'
-  url: https://www.singledigitalpresence.vic.gov.au/cms-components
-  weight: -30
-  options:
-    attributes:
-      target: _blank
-tide_cms_support.cms_media_items:
-  title: 'Media items'
-  description: 'Instructions on how to add and embed images, videos, audio files and documents onto your webpage.'
-  parent: 'tide_cms_support.cms_guides'
-  url: https://www.singledigitalpresence.vic.gov.au/images-video-audio-documents
-  weight: -20
-  options:
-    attributes:
-      target: _blank
-tide_cms_support.cms_content_support:
-  title: 'Content support'
-  description: 'Follow these steps if you have a question about using the Single Digital Presence content management system.'
-  parent: 'tide_cms_support.cms_guides'
-  url: https://www.singledigitalpresence.vic.gov.au/get-cms-content-support
-  weight: -10
   options:
     attributes:
       target: _blank

--- a/tests/behat/features/cms_support.feature
+++ b/tests/behat/features/cms_support.feature
@@ -4,7 +4,7 @@ Feature: CMS Support
   @api
   Scenario Outline: User logs into the CMS and clicks on the Manage tab
     Given I am logged in as a user with the "<role>" role
-    Then I should find menu item text matching "CMS Support"
+    Then I should find menu item text matching "Help"
     Examples:
       | role            |
       | administrator   |


### PR DESCRIPTION
### Jira
https://digital-vic.atlassian.net/browse/SDPAP-8367

### Change
> Please remove the remove dropdown items from the ‘CMS Support’ tab in the CMS. Instead could we please change the text ‘CMS support’ to ‘Help’ and link straight to [SDP Help Centre](https://digital-vic.atlassian.net/servicedesk/customer/portal/14/article/2030338745?src=1792308362).
