### PR TITLE
[SDPAP-6864]Approvers should not be able to publish Alerts

### DIFF
--- a/config/install/user.role.approver.yml
+++ b/config/install/user.role.approver.yml
@@ -30,7 +30,6 @@ permissions:
   - 'administer webform element access'
   - 'administer webform submission'
   - 'break content lock'
-  - 'create alert content'
   - 'create image_gallery content'
   - 'create landing_page content'
   - 'create media'

--- a/tide_core.install
+++ b/tide_core.install
@@ -2014,3 +2014,12 @@ function tide_core_update_8098() {
   $approver->grantPermission('tide node bulk update');
   $approver->save();
 }
+
+/**
+ * Revoke the permission of creating alerts from the approver role.
+ */
+function tide_core_update_8099() {
+  $approver = Role::load('approver');
+  $approver->revokePermission('create alert content');
+  $approver->save();
+}


### PR DESCRIPTION
### Jira
https://digital-vic.atlassian.net/browse/SDPAP-6864

### change
revokes `create alert content` from approver roles.
