### PR TITLE
Added custom css to adjust the width of node form to match SDP current design.

### DIFF
--- a/css/claro_layout.css
+++ b/css/claro_layout.css
@@ -1,4 +1,9 @@
 @media screen and (min-width: 61rem) {
+  .layout-region--node-main,
+  .layout-region--node-footer {
+    margin-inline: unset !important;
+    width: unset !important;
+  }
   .layout-region--node-main .layout-region__content,
   .layout-region--node-footer .layout-region__content {
     max-width: 100rem !important;

--- a/tide_core.libraries.yml
+++ b/tide_core.libraries.yml
@@ -1,17 +1,17 @@
 content_moderation:
-  version: VERSION
+  version: 1.0
   css:
     component:
       css/content_moderation.module.css: {}
     theme:
       css/content_moderation.theme.css: {}
 ckeditor_stylesheets:
-  version: VERSION
+  version: 1.0
   css:
     theme:
       css/ckeditor_overrides.css: {}
 sticky_node_form_sidebar:
-  version: VERSION
+  version: 1.0
   css:
     theme:
       css/sticky_node_form_sidebar.css: {}
@@ -32,7 +32,7 @@ editor_autolink:
     - core/drupal
 
 claro_layout:
-  version: VERSION
+  version: 1.0
   css:
     theme:
       css/claro_layout.css: {}


### PR DESCRIPTION

### Jira
https://digital-vic.atlassian.net/browse/SRM-1187
### Problem/Motivation
There are some new css changes in the BE in D10 and which changes our default design for node add/edit form.
### Fix
Added custom css to retain the fullwidth design for node add/edit form
### Related PRs

### Screenshots
The current screenshot after fix - 
<img width="1919" alt="Screenshot 2023-11-27 at 5 27 03 pm" src="https://github.com/dpc-sdp/tide_core/assets/20810541/26dae765-a1d4-4400-bb93-72cba4541e85">

See the screenshots of the issue in the ticket
### TODO
