### PR TITLE
[SRM-1174] update views_data_export’s patch

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -266,7 +266,7 @@
             },
             "drupal/views_data_export": {
                 "Batch mode does not allow other modules to alter query - https://www.drupal.org/project/views_data_export/issues/3173296#comment-14930767": "https://www.drupal.org/files/issues/2023-02-20/views_data_export-3173296-25.patch",
-                "Support views data export using drush - https://www.drupal.org/project/views_data_export/issues/2887450#comment-15199879": "https://www.drupal.org/files/issues/2023-08-21/vde-drush-with-output-location-2887450-85.patch"
+                "Support views data export using drush - https://www.drupal.org/project/views_data_export/issues/2887450#comment-15199879": "https://www.drupal.org/files/issues/2023-11-29/vde-drush-with-output-location-2887450-91.patch"
             }
         }
     },


### PR DESCRIPTION
### Jira
https://digital-vic.atlassian.net/browse/SRM-1174

it works fine with D10
```cli
[content-vic]cli-drupal:/app$ drush cron
 [warning] Processing per role expiration warning.
 [notice] Starting data export..
>  [notice] operation:insert, description:private://views_data_export/vsba_data_extract_data_export_1/1-1701311478/vsba_data_extract.csv, ref_numeric:620168, ref_char:vsba_data_extract.csv, uid:1, path:
>  [notice] operation:update, description:private://views_data_export/vsba_data_extract_data_export_1/1-1701311478/vsba_data_extract.csv, ref_numeric:620168, ref_char:vsba_data_extract.csv, uid:1, path:
>  [notice] Data export saved to private://views_data_export/extract.csv
 [success] Data export finished.
```