### PR TITLE
adding patch for content lock

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -252,7 +252,8 @@
                 "Dropbutton RHS highlight covers adjacent text - https://www.drupal.org/project/paragraphs/issues/3350747#comment-14986371": "https://www.drupal.org/files/issues/2023-03-28/paragraph-dropdown-button-obscure-text-2.patch"
             },
             "drupal/content_lock": {
-                "Altering timeout message - https://www.drupal.org/project/content_lock/issues/3214877#comment-14108752": "https://www.drupal.org/files/issues/2021-05-20/content_lock_3214877_3.patch"
+                "Altering timeout message - https://www.drupal.org/project/content_lock/issues/3214877#comment-14108752": "https://www.drupal.org/files/issues/2021-05-20/content_lock_3214877_3.patch",
+                "Fix PHP 8.2+ deprecation notices - https://www.drupal.org/project/content_lock/issues/3343964#comment-15061454": "https://www.drupal.org/files/issues/2023-05-22/3343964-5.patch"
             },
             "lesstif/php-jira-rest-client": {
                 "Supports email lookup": "https://patch-diff.githubusercontent.com/raw/dpc-sdp/php-jira-rest-client/pull/1.diff"


### PR DESCRIPTION
### Jira

### Problem/Motivation

The following warning pops up when pushing a pr in tide_api and it is because of 
deprecated function: Creation of dynamic property Drupal\content_lock\ContentLock\ContentLock::$time is deprecated in Drupal\content_lock\ContentLock\ContentLock->__construct() (line 139 of modules/contrib/content_lock/src/ContentLock/ContentLock.php).
https://www.drupal.org/project/content_lock/issues/3343964

### Fix

### Related PRs

### Screenshots
![Screenshot 2024-01-23 at 4 54 03 pm](https://github.com/dpc-sdp/tide_core/assets/47239456/fb244eb1-619d-4215-b1df-9c7f9258118f)


### TODO
