### PR TITLE
Locked respect/validation to latest release to avoid composer conflicts.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -76,7 +76,7 @@
         "lesstif/php-jira-rest-client": "2.6.0",
         "drupal/jira_rest": "^4.0@beta",
         "drupal/ckeditor5_embedded_content": "1.0.1",
-        "respect/validation": "dev-master",
+        "respect/validation": "2.3.1",
         "giggsey/libphonenumber-for-php": "^8.13",
         "drupal/site_alert": "^1.3",
         "lcobucci/clock": "3.0.0"


### PR DESCRIPTION
### Jira

### Problem/Motivation
dev-master has an update for symfony/polyfill-mbstring which creates conflicts with drupal core 10.1.x dependency.
### Fix
Lock it to a stable latest release tag to avoid this conflicts.
### Related PRs

### Screenshots

### TODO
