### PR TITLE
Updated config_split version with the recent release.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
         "drupal/clamav": "2.0.2-rc1",
         "drupal/config_ignore": "^2.4",
         "drupal/config_perms": "2.x-dev@dev",
-        "drupal/config_split": "^1.9",
+        "drupal/config_split": "^2.0",
         "drupal/config_update": "^2.0@alpha",
         "drupal/core": "10.1.7",
         "drupal/core-recommended": "10.1.7",


### PR DESCRIPTION
### Jira

### Problem/Motivation
Recent release has bug fixes and also some projects using config_filter 2.0 and that is why the newer version becomes a dependency.
### Fix
Upgraded config_split with newer release.
### Related PRs

### Screenshots

### TODO
