### PR TITLE
[SDPAP-8964] Added "Audit Files" module to assist content authors to identify anomalies with managed files

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,6 +10,7 @@
         "jquery/textcounter": "0.9.1",
         "drupal/address": "^1.4",
         "drupal/allowed_formats": "^2.0",
+        "drupal/auditfiles": "*",
         "drupal/better_exposed_filters": "^6.0",
         "drupal/clamav": "2.0.2-rc1",
         "drupal/config_ignore": "^2.4",

--- a/tide_core.info.yml
+++ b/tide_core.info.yml
@@ -6,6 +6,7 @@ core_version_requirement: ^9 || ^10
 dependencies:
   - address:address
   - allowed_formats:allowed_formats
+  - auditfiles:auditfiles
   - better_exposed_filters:better_exposed_filters
   - ckeditor5_embedded_content:ckeditor5_embedded_content
   - clamav:clamav

--- a/tide_core.install
+++ b/tide_core.install
@@ -139,3 +139,10 @@ function tide_core_update_10004() {
     user_role_revoke_permissions($role, $permissions);
   }
 }
+
+/**
+ * Enable auditfiles module.
+ */
+function tide_core_update_10005() {
+  \Drupal::service('module_installer')->install(['auditfiles']);
+}


### PR DESCRIPTION
### Jira

https://digital-vic.atlassian.net/browse/SDPAP-8964

### Problem/Motivation

There are a number of support tickets relating to managed files that can be difficult to track down the root cause.

The [Audit Files](https://www.drupal.org/project/auditfiles) module adds reports to the admin area which help identify anomalies. Such as files not being used anywhere, files in the database that are missing from disk, and a few others.

### Fix

This module, once deployed, will allow support (and CMS users potentially, if we decide to give them access) to identify problems with files.

### Screenshots
![Screenshot 2024-02-23 at 2 13 37 pm](https://github.com/dpc-sdp/tide_core/assets/121107/6276bb8d-4a60-4e4d-8761-40b6f22a1e6c)
![Screenshot 2024-02-23 at 2 14 11 pm](https://github.com/dpc-sdp/tide_core/assets/121107/c1fbe4c4-bd9e-4270-9660-063aae68219b)
![Screenshot 2024-02-23 at 2 14 25 pm](https://github.com/dpc-sdp/tide_core/assets/121107/25c2f953-410a-4a76-bf3c-a2ea5e735e70)
![Screenshot 2024-02-23 at 2 14 46 pm](https://github.com/dpc-sdp/tide_core/assets/121107/58e27dd3-6732-4eda-aed5-a626ca5b84f1)



### TODO
