### PR TITLE
remove field-group patch that has been rerolled

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -230,9 +230,6 @@
             "drupal/token": {
                 "Summary token not fully handled in fields - https://www.drupal.org/project/token/issues/2924873#comment-15704936": "https://www.drupal.org/files/issues/2024-07-30/tokens_body_with_summary-2924873-18.patch"
             },
-            "drupal/field_group": {
-                "Tabs with invalid input are not focused - https://www.drupal.org/project/field_group/issues/2894351#comment-14063815": "https://www.drupal.org/files/issues/2021-04-18/2894351-23.patch"
-            },
             "drupal/jira_rest": {
                 "Automated Drupal 10 compatibility fixes - https://www.drupal.org/project/jira_rest/issues/3288088#comment-14567776": "https://www.drupal.org/files/issues/2022-06-16/jira_rest.4.x-dev.rector.patch"
             },

--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
         "drupal/entity_embed": "1.x-dev@dev",
         "drupal/environment_indicator": "^4.0",
         "drupal/fast_404": "^3.0",
-        "drupal/field_group": "^3.4",
+        "drupal/field_group": "^3.6",
         "drupal/google_analytics": "^4.0",
         "drupal/hotjar": "^3.1",
         "drupal/linkit": "^6.0.0",

--- a/composer.json
+++ b/composer.json
@@ -231,7 +231,6 @@
                 "Summary token not fully handled in fields - https://www.drupal.org/project/token/issues/2924873#comment-15704936": "https://www.drupal.org/files/issues/2024-07-30/tokens_body_with_summary-2924873-18.patch"
             },
             "drupal/field_group": {
-                "Nested groups render on other entity forms (or when fields are inaccessible) when they shouldn't: https://www.drupal.org/project/field_group/issues/3098550": "https://www.drupal.org/files/issues/2020-06-18/3098550-12.patch",
                 "Tabs with invalid input are not focused - https://www.drupal.org/project/field_group/issues/2894351#comment-14063815": "https://www.drupal.org/files/issues/2021-04-18/2894351-23.patch"
             },
             "drupal/jira_rest": {


### PR DESCRIPTION
### Jira
![Screenshot 2024-08-05 at 11 22 20 am](https://github.com/user-attachments/assets/99609660-6134-4d51-8c4f-af425b0c8947)

### Problem/Motivation
This issue https://www.drupal.org/project/field_group/issues/3098550 has been resolved and patch is not needed it anymore
### Fix
Remove patch
### Related PRs

### Screenshots

### TODO
