### PR TITLE
[SD-188] tide version information

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,6 +18,7 @@
         "drupal/config_update": "^2.0@alpha",
         "drupal/core": "10.3.x",
         "drupal/core-recommended": "10.3.x",
+        "drupal/monitoring": "^1.13",
         "drupal/ckeditor_templates": "dev-feature/d10-compatible-with-ck5-support",
         "drupal/ctools": "^3.14",
         "drupal/diff": "^1.1",

--- a/config/install/monitoring.sensor_config.tide_times.yml
+++ b/config/install/monitoring.sensor_config.tide_times.yml
@@ -1,0 +1,12 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - system
+    - monitoring
+id: tide_times
+label: 'Tide times'
+description: 'Information Hub for Tide Modules.'
+category: 'Tide'
+plugin_id: tide_times_sensor
+caching_time: 3600

--- a/config/install/monitoring.sensor_config.tide_times.yml
+++ b/config/install/monitoring.sensor_config.tide_times.yml
@@ -9,4 +9,3 @@ label: 'Tide times'
 description: 'Information Hub for Tide Modules.'
 category: 'Tide'
 plugin_id: tide_times_sensor
-caching_time: 3600

--- a/src/Controller/SystemInfoController.php
+++ b/src/Controller/SystemInfoController.php
@@ -3,10 +3,10 @@
 namespace Drupal\tide_core\Controller;
 
 use Drupal\Core\Cache\CacheableJsonResponse;
+use Drupal\Core\Cache\CacheableMetadata;
 use Drupal\Core\Controller\ControllerBase;
 use Drupal\tide_core\TideSystemInfoService;
 use Symfony\Component\DependencyInjection\ContainerInterface;
-use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 
@@ -79,7 +79,9 @@ class SystemInfoController extends ControllerBase {
   public function getPackageVersion(Request $request) {
     $packageName = $request->query->get('q');
     $data = $this->systemInfoService->getPackageVersion($packageName);
-    return new JsonResponse($data);
+    $response = new CacheableJsonResponse($data);
+    $response->addCacheableDependency((new CacheableMetadata())->addCacheContexts(['url.query_args:q']));
+    return $response;
   }
 
 }

--- a/src/Controller/SystemInfoController.php
+++ b/src/Controller/SystemInfoController.php
@@ -2,11 +2,17 @@
 
 namespace Drupal\tide_core\Controller;
 
-use Drupal\Core\Cache\CacheBackendInterface;
+use Drupal\Core\Entity\ContentEntityInterface;
 use Drupal\Core\Controller\ControllerBase;
-use Symfony\Component\DependencyInjection\ContainerInterface;
+use Drupal\Core\Entity\EntityFieldManagerInterface;
+use Drupal\Core\Entity\EntityTypeBundleInfoInterface;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Symfony\Component\HttpFoundation\JsonResponse;
+use Drupal\Core\Cache\CacheBackendInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Drupal\Core\State\StateInterface;
 use Symfony\Component\HttpFoundation\Response;
+use Psr\Log\LoggerInterface;
 
 /**
  * Returns system information including tide and sdp versions.
@@ -14,33 +20,90 @@ use Symfony\Component\HttpFoundation\Response;
 class SystemInfoController extends ControllerBase {
 
   /**
-   * Cache backend interface.
+   * The cache backend.
    *
    * @var \Drupal\Core\Cache\CacheBackendInterface
    */
   protected $cacheBackend;
 
   /**
+   * The state service.
+   *
+   * @var \Drupal\Core\State\StateInterface
+   */
+  protected $state;
+
+  /**
+   * The entity type manager.
+   *
+   * @var \Drupal\Core\Entity\EntityTypeManagerInterface
+   */
+  protected $entityTypeManager;
+
+  /**
+   * The entity type bundle info.
+   *
+   * @var \Drupal\Core\Entity\EntityTypeBundleInfoInterface
+   */
+  protected $entityTypeBundleInfo;
+
+  /**
+   * The entity field manager.
+   *
+   * @var \Drupal\Core\Entity\EntityFieldManagerInterface
+   */
+  protected $entityFieldManager;
+
+  /**
+   * The logger.
+   *
+   * @var \Psr\Log\LoggerInterface
+   */
+  protected $logger;
+
+  /**
    * Constructs a SystemInfoController object.
    *
    * @param \Drupal\Core\Cache\CacheBackendInterface $cache_backend
    *   The cache backend interface.
+   * @param \Drupal\Core\State\StateInterface $state
+   *   The state service.
+   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
+   *   The entity type manager.
+   * @param \Drupal\Core\Entity\EntityTypeBundleInfoInterface $entity_type_bundle_info
+   *   The entity type bundle info.
+   * @param \Drupal\Core\Entity\EntityFieldManagerInterface $entity_field_manager
+   *   The entity field manager.
+   * @param \Psr\Log\LoggerInterface $logger
+   *   The logger.
    */
-  public function __construct(CacheBackendInterface $cache_backend) {
-    $this->cacheBackend = $cache_backend;
+  public function __construct(
+    CacheBackendInterface $cache_backend,
+    StateInterface $state,
+    EntityTypeManagerInterface $entity_type_manager,
+    EntityTypeBundleInfoInterface $entity_type_bundle_info,
+    EntityFieldManagerInterface $entity_field_manager,
+    LoggerInterface $logger
+  ) {
+    $this->cacheBackend         = $cache_backend;
+    $this->state                = $state;
+    $this->entityTypeManager    = $entity_type_manager;
+    $this->entityTypeBundleInfo = $entity_type_bundle_info;
+    $this->entityFieldManager   = $entity_field_manager;
+    $this->logger               = $logger;
   }
 
   /**
-   * Dependency injection.
-   *
-   * @param \Symfony\Component\DependencyInjection\ContainerInterface $container
-   *   The service container.
-   *
-   * @return static
+   * {@inheritdoc}
    */
   public static function create(ContainerInterface $container) {
     return new static(
-      $container->get('cache.default')
+      $container->get('cache.default'),
+      $container->get('state'),
+      $container->get('entity_type.manager'),
+      $container->get('entity_type.bundle.info'),
+      $container->get('entity_field.manager'),
+      $container->get('logger.factory')->get('tide_core')
     );
   }
 
@@ -51,7 +114,7 @@ class SystemInfoController extends ControllerBase {
    *   The system information in JSON format.
    */
   public function getSystemInfo() {
-    $cid = 'system_info:composer_versions';
+    $cid = 'tide_core:system_info:composer_versions';
 
     if ($cache = $this->cacheBackend->get($cid)) {
       return new JsonResponse($cache->data);
@@ -60,22 +123,158 @@ class SystemInfoController extends ControllerBase {
     $composer_file_path = DRUPAL_ROOT . '/../composer.json';
 
     if (!file_exists($composer_file_path)) {
-      return new JsonResponse(['error' => 'composer.json not found'], Response::HTTP_NOT_FOUND);
+      $this->logger->error('composer.json not found at @path',
+        ['@path' => $composer_file_path]);
+      return new JsonResponse(['error' => 'composer.json not found'],
+        Response::HTTP_NOT_FOUND);
     }
 
     $composer_data = json_decode(file_get_contents($composer_file_path), TRUE);
 
-    $sdp_version = $composer_data['extra']['sdp_version'] ?? 'unknown';
-    $tide_version = $composer_data['require']['dpc-sdp/tide'] ?? 'unknown';
-
     $data = [
-      'tideVersion' => $tide_version,
-      'sdpVersion' => $sdp_version,
+      'tideVersion' => $composer_data['require']['dpc-sdp/tide'] ?? 'unknown',
+      'sdpVersion'  => $composer_data['extra']['sdp_version'] ?? 'unknown',
     ];
 
-    $this->cacheBackend->set($cid, $data, time() + 3600);
+    $this->cacheBackend->set($cid,
+      $data,
+      $this->state->get('tide_core.cache_lifetime', 3600));
 
     return new JsonResponse($data);
+  }
+
+  /**
+   * Returns custom field information for specified entity types.
+   *
+   * @param string $types
+   *   Comma-separated list of entity types or 'all'.
+   *
+   * @return \Symfony\Component\HttpFoundation\JsonResponse
+   *   The field information in JSON format.
+   */
+  public function getFields($types = 'all') {
+    try {
+      $requestedTypes = $types === 'all' ? [] : explode(',', $types);
+
+      $validTypes   = $this->getValidEntityTypes();
+      $invalidTypes = array_diff($requestedTypes, $validTypes);
+
+      if (!empty($invalidTypes)) {
+        return new JsonResponse([
+          'error'       => 'Invalid entity type(s): ' . implode(', ',
+              $invalidTypes),
+          'valid_types' => $validTypes,
+        ], Response::HTTP_BAD_REQUEST);
+      }
+
+      $data = $this->getCustomFieldIds($requestedTypes);
+      return new JsonResponse($data);
+    }
+    catch (\Exception $e) {
+      $this->logger->error('Error fetching field information: @message',
+        ['@message' => $e->getMessage()]);
+      return new JsonResponse(['error' => 'An error occurred while fetching field information.'],
+            Response::HTTP_INTERNAL_SERVER_ERROR);
+    }
+  }
+
+  /**
+   * Returns custom field IDs for specified entity types.
+   *
+   * @param array $requestedTypes
+   *   Array of requested entity types.
+   *
+   * @return array
+   *   Array of custom field IDs grouped by entity type and bundle.
+   */
+  private function getCustomFieldIds(array $requestedTypes = []) {
+    $cid = 'tide_core:system_info:fields:' . md5(implode(',',
+        $requestedTypes));
+
+    if ($cache = $this->cacheBackend->get($cid)) {
+      return $cache->data;
+    }
+
+    $result = [];
+
+    $entityTypes = $this->entityTypeManager->getDefinitions();
+
+    foreach ($entityTypes as $entityTypeId => $entityType) {
+      if (!$entityType->entityClassImplements(ContentEntityInterface::class)) {
+        continue;
+      }
+
+      if (!empty($requestedTypes)
+          && !in_array($entityTypeId,
+          $requestedTypes)
+      ) {
+        continue;
+      }
+
+      $result[$entityTypeId] = [];
+
+      $bundles = $this->entityTypeBundleInfo->getBundleInfo($entityTypeId);
+      foreach ($bundles as $bundleId => $bundleInfo) {
+        $result[$entityTypeId][$bundleId]
+          = $this->getEntityCustomFields($entityTypeId, $bundleId);
+      }
+    }
+
+    $this->cacheBackend->set($cid,
+      $result,
+      $this->state->get('tide_core.cache_lifetime', 3600));
+
+    return $result;
+  }
+
+  /**
+   * Returns custom fields for a specific entity type and bundle.
+   *
+   * @param string $entityTypeId
+   *   The entity type ID.
+   * @param string $bundleId
+   *   The bundle ID.
+   *
+   * @return array
+   *   Array of custom field names.
+   */
+  private function getEntityCustomFields($entityTypeId, $bundleId) {
+    $fieldDefinitions
+      = $this->entityFieldManager->getFieldDefinitions($entityTypeId,
+      $bundleId);
+    return array_values(array_filter(array_keys($fieldDefinitions),
+      function ($fieldName) use ($fieldDefinitions) {
+        $fieldDefinition = $fieldDefinitions[$fieldName];
+        return !$fieldDefinition->isComputed()
+               && strpos($fieldName, 'field_') === 0;
+      }));
+  }
+
+  /**
+   * Returns all valid entity types.
+   *
+   * @return array
+   *   Array of valid entity type IDs.
+   */
+  private function getValidEntityTypes() {
+    $cid = 'tide_core:system_info:valid_entity_types';
+
+    if ($cache = $this->cacheBackend->get($cid)) {
+      return $cache->data;
+    }
+
+    $validTypes = array_keys(array_filter(
+      $this->entityTypeManager->getDefinitions(),
+      function ($entityType) {
+        return $entityType->entityClassImplements(ContentEntityInterface::class);
+      }
+    ));
+
+    $this->cacheBackend->set($cid,
+      $validTypes,
+      $this->state->get('tide_core.cache_lifetime', 86400));
+
+    return $validTypes;
   }
 
 }

--- a/src/Controller/SystemInfoController.php
+++ b/src/Controller/SystemInfoController.php
@@ -1,0 +1,81 @@
+<?php
+
+namespace Drupal\tide_core\Controller;
+
+use Drupal\Core\Cache\CacheBackendInterface;
+use Drupal\Core\Controller\ControllerBase;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * Returns system information including tide and sdp versions.
+ */
+class SystemInfoController extends ControllerBase {
+
+  /**
+   * Cache backend interface.
+   *
+   * @var \Drupal\Core\Cache\CacheBackendInterface
+   */
+  protected $cacheBackend;
+
+  /**
+   * Constructs a SystemInfoController object.
+   *
+   * @param \Drupal\Core\Cache\CacheBackendInterface $cache_backend
+   *   The cache backend interface.
+   */
+  public function __construct(CacheBackendInterface $cache_backend) {
+    $this->cacheBackend = $cache_backend;
+  }
+
+  /**
+   * Dependency injection.
+   *
+   * @param \Symfony\Component\DependencyInjection\ContainerInterface $container
+   *   The service container.
+   *
+   * @return static
+   */
+  public static function create(ContainerInterface $container) {
+    return new static(
+      $container->get('cache.default')
+    );
+  }
+
+  /**
+   * Reads composer.json and returns tide and sdp versions.
+   *
+   * @return \Symfony\Component\HttpFoundation\JsonResponse
+   *   The system information in JSON format.
+   */
+  public function getSystemInfo() {
+    $cid = 'system_info:composer_versions';
+
+    if ($cache = $this->cacheBackend->get($cid)) {
+      return new JsonResponse($cache->data);
+    }
+
+    $composer_file_path = DRUPAL_ROOT . '/../composer.json';
+
+    if (!file_exists($composer_file_path)) {
+      return new JsonResponse(['error' => 'composer.json not found'], Response::HTTP_NOT_FOUND);
+    }
+
+    $composer_data = json_decode(file_get_contents($composer_file_path), TRUE);
+
+    $sdp_version = $composer_data['extra']['sdp_version'] ?? 'unknown';
+    $tide_version = $composer_data['require']['dpc-sdp/tide'] ?? 'unknown';
+
+    $data = [
+      'tideVersion' => $tide_version,
+      'sdpVersion' => $sdp_version,
+    ];
+
+    $this->cacheBackend->set($cid, $data, time() + 3600);
+
+    return new JsonResponse($data);
+  }
+
+}

--- a/src/Controller/SystemInfoController.php
+++ b/src/Controller/SystemInfoController.php
@@ -3,14 +3,8 @@
 namespace Drupal\tide_core\Controller;
 
 use Drupal\Core\Cache\CacheableJsonResponse;
-use Drupal\Core\Cache\CacheBackendInterface;
 use Drupal\Core\Controller\ControllerBase;
-use Drupal\Core\Entity\ContentEntityInterface;
-use Drupal\Core\Entity\EntityFieldManagerInterface;
-use Drupal\Core\Entity\EntityTypeBundleInfoInterface;
-use Drupal\Core\Entity\EntityTypeManagerInterface;
-use Drupal\Core\State\StateInterface;
-use Psr\Log\LoggerInterface;
+use Drupal\tide_core\TideSystemInfoService;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -21,77 +15,20 @@ use Symfony\Component\HttpFoundation\Response;
 class SystemInfoController extends ControllerBase {
 
   /**
-   * The cache backend.
+   * The system info service.
    *
-   * @var \Drupal\Core\Cache\CacheBackendInterface
+   * @var \Drupal\tide_core\TideSystemInfoService
    */
-  protected $cacheBackend;
-
-  /**
-   * The state service.
-   *
-   * @var \Drupal\Core\State\StateInterface
-   */
-  protected $state;
-
-  /**
-   * The entity type manager.
-   *
-   * @var \Drupal\Core\Entity\EntityTypeManagerInterface
-   */
-  protected $entityTypeManager;
-
-  /**
-   * The entity type bundle info.
-   *
-   * @var \Drupal\Core\Entity\EntityTypeBundleInfoInterface
-   */
-  protected $entityTypeBundleInfo;
-
-  /**
-   * The entity field manager.
-   *
-   * @var \Drupal\Core\Entity\EntityFieldManagerInterface
-   */
-  protected $entityFieldManager;
-
-  /**
-   * The logger.
-   *
-   * @var \Psr\Log\LoggerInterface
-   */
-  protected $logger;
+  protected $systemInfoService;
 
   /**
    * Constructs a SystemInfoController object.
    *
-   * @param \Drupal\Core\Cache\CacheBackendInterface $cache_backend
-   *   The cache backend interface.
-   * @param \Drupal\Core\State\StateInterface $state
-   *   The state service.
-   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
-   *   The entity type manager.
-   * @param \Drupal\Core\Entity\EntityTypeBundleInfoInterface $entity_type_bundle_info
-   *   The entity type bundle info.
-   * @param \Drupal\Core\Entity\EntityFieldManagerInterface $entity_field_manager
-   *   The entity field manager.
-   * @param \Psr\Log\LoggerInterface $logger
-   *   The logger.
+   * @param \Drupal\tide_core\TideSystemInfoService $system_info_service
+   *   The system info service.
    */
-  public function __construct(
-    CacheBackendInterface $cache_backend,
-    StateInterface $state,
-    EntityTypeManagerInterface $entity_type_manager,
-    EntityTypeBundleInfoInterface $entity_type_bundle_info,
-    EntityFieldManagerInterface $entity_field_manager,
-    LoggerInterface $logger
-  ) {
-    $this->cacheBackend         = $cache_backend;
-    $this->state                = $state;
-    $this->entityTypeManager    = $entity_type_manager;
-    $this->entityTypeBundleInfo = $entity_type_bundle_info;
-    $this->entityFieldManager   = $entity_field_manager;
-    $this->logger               = $logger;
+  public function __construct(TideSystemInfoService $system_info_service) {
+    $this->systemInfoService = $system_info_service;
   }
 
   /**
@@ -99,46 +36,8 @@ class SystemInfoController extends ControllerBase {
    */
   public static function create(ContainerInterface $container) {
     return new static(
-      $container->get('cache.default'),
-      $container->get('state'),
-      $container->get('entity_type.manager'),
-      $container->get('entity_type.bundle.info'),
-      $container->get('entity_field.manager'),
-      $container->get('logger.factory')->get('tide_core')
+      $container->get('tide_core.system_info_service')
     );
-  }
-
-  /**
-   * Reads composer.json and returns tide and sdp versions.
-   *
-   * @return \Symfony\Component\HttpFoundation\JsonResponse
-   *   The system information in JSON format.
-   */
-  public function getSystemInfo() {
-    $cid = 'tide_core:system_info:composer_versions';
-
-    if ($cache = $this->cacheBackend->get($cid)) {
-      return new CacheableJsonResponse($cache->data);
-    }
-
-    $file_system = \Drupal::service('file_system');
-    $composer_file_path = $file_system->realpath(DRUPAL_ROOT . '/../composer.json');
-
-    if (!file_exists($composer_file_path)) {
-      $this->logger->error('composer.json not found at @path', ['@path' => $composer_file_path]);
-      return new CacheableJsonResponse(['error' => 'composer.json not found'], Response::HTTP_NOT_FOUND);
-    }
-
-    $composer_data = json_decode(file_get_contents($composer_file_path), TRUE);
-
-    $data = [
-      'tideVersion' => $composer_data['require']['dpc-sdp/tide'] ?? 'unknown',
-      'sdpVersion' => $composer_data['extra']['sdp_version'] ?? 'unknown',
-    ];
-
-    $this->cacheBackend->set($cid, $data, $this->state->get('tide_core.cache_lifetime', 3600));
-
-    return new CacheableJsonResponse($data);
   }
 
   /**
@@ -151,128 +50,20 @@ class SystemInfoController extends ControllerBase {
    *   The field information in JSON format.
    */
   public function getFields($types = 'all') {
-    try {
-      $requestedTypes = $types === 'all' ? [] : explode(',', $types);
+    $requestedTypes = $types === 'all' ? [] : explode(',', $types);
 
-      $validTypes   = $this->getValidEntityTypes();
-      $invalidTypes = array_diff($requestedTypes, $validTypes);
+    $validTypes = $this->systemInfoService->getValidEntityTypes();
+    $invalidTypes = array_diff($requestedTypes, $validTypes);
 
-      if (!empty($invalidTypes)) {
-        return new CacheableJsonResponse([
-          'error'       => 'Invalid entity type(s): ' . implode(', ',
-              $invalidTypes),
-          'valid_types' => $validTypes,
-        ], Response::HTTP_BAD_REQUEST);
-      }
-
-      $data = $this->getCustomFieldIds($requestedTypes);
-      return new CacheableJsonResponse($data);
-    }
-    catch (\Exception $e) {
-      $this->logger->error('Error fetching field information: @message',
-        ['@message' => $e->getMessage()]);
-      return new CacheableJsonResponse(['error' => 'An error occurred while fetching field information.'],
-            Response::HTTP_INTERNAL_SERVER_ERROR);
-    }
-  }
-
-  /**
-   * Returns custom field IDs for specified entity types.
-   *
-   * @param array $requestedTypes
-   *   Array of requested entity types.
-   *
-   * @return array
-   *   Array of custom field IDs grouped by entity type and bundle.
-   */
-  private function getCustomFieldIds(array $requestedTypes = []) {
-    $cid = 'tide_core:system_info:fields:' . md5(implode(',',
-        $requestedTypes));
-
-    if ($cache = $this->cacheBackend->get($cid)) {
-      return $cache->data;
+    if (!empty($invalidTypes)) {
+      return new CacheableJsonResponse([
+        'error' => 'Invalid entity type(s): ' . implode(', ', $invalidTypes),
+        'valid_types' => $validTypes,
+      ], Response::HTTP_BAD_REQUEST);
     }
 
-    $result = [];
-
-    $entityTypes = $this->entityTypeManager->getDefinitions();
-
-    foreach ($entityTypes as $entityTypeId => $entityType) {
-      if (!$entityType->entityClassImplements(ContentEntityInterface::class)) {
-        continue;
-      }
-
-      if (!empty($requestedTypes)
-          && !in_array($entityTypeId,
-          $requestedTypes)
-      ) {
-        continue;
-      }
-
-      $result[$entityTypeId] = [];
-
-      $bundles = $this->entityTypeBundleInfo->getBundleInfo($entityTypeId);
-      foreach ($bundles as $bundleId => $bundleInfo) {
-        $result[$entityTypeId][$bundleId]
-          = $this->getEntityCustomFields($entityTypeId, $bundleId);
-      }
-    }
-
-    $this->cacheBackend->set($cid,
-      $result,
-      $this->state->get('tide_core.cache_lifetime', 3600));
-
-    return $result;
-  }
-
-  /**
-   * Returns custom fields for a specific entity type and bundle.
-   *
-   * @param string $entityTypeId
-   *   The entity type ID.
-   * @param string $bundleId
-   *   The bundle ID.
-   *
-   * @return array
-   *   Array of custom field names.
-   */
-  private function getEntityCustomFields($entityTypeId, $bundleId) {
-    $fieldDefinitions
-      = $this->entityFieldManager->getFieldDefinitions($entityTypeId,
-      $bundleId);
-    return array_values(array_filter(array_keys($fieldDefinitions),
-      function ($fieldName) use ($fieldDefinitions) {
-        $fieldDefinition = $fieldDefinitions[$fieldName];
-        return !$fieldDefinition->isComputed()
-               && strpos($fieldName, 'field_') === 0;
-      }));
-  }
-
-  /**
-   * Returns all valid entity types.
-   *
-   * @return array
-   *   Array of valid entity type IDs.
-   */
-  private function getValidEntityTypes() {
-    $cid = 'tide_core:system_info:valid_entity_types';
-
-    if ($cache = $this->cacheBackend->get($cid)) {
-      return $cache->data;
-    }
-
-    $validTypes = array_keys(array_filter(
-      $this->entityTypeManager->getDefinitions(),
-      function ($entityType) {
-        return $entityType->entityClassImplements(ContentEntityInterface::class);
-      }
-    ));
-
-    $this->cacheBackend->set($cid,
-      $validTypes,
-      $this->state->get('tide_core.cache_lifetime', 86400));
-
-    return $validTypes;
+    $data = $this->systemInfoService->getCustomFields($requestedTypes);
+    return new CacheableJsonResponse($data);
   }
 
   /**
@@ -286,71 +77,8 @@ class SystemInfoController extends ControllerBase {
    */
   public function getPackageVersion(Request $request) {
     $packageName = $request->query->get('q');
-
-    if (empty($packageName)) {
-      return new CacheableJsonResponse(['error' => 'Package name is required.'], Response::HTTP_BAD_REQUEST);
-    }
-
-    if (strtolower($packageName) === 'php') {
-      $data = [
-        'package' => 'php',
-        'version' => PHP_VERSION,
-      ];
-      return new CacheableJsonResponse($data);
-    }
-
-    $cid = 'tide_core:system_info:package_version:' . md5($packageName);
-
-    if ($cache = $this->cacheBackend->get($cid)) {
-      return new CacheableJsonResponse($cache->data);
-    }
-
-    $file_system = \Drupal::service('file_system');
-    $composer_lock_path = $file_system->realpath(DRUPAL_ROOT . '/../composer.lock');
-
-    if (!file_exists($composer_lock_path)) {
-      $this->logger->error('composer.lock not found at @path', ['@path' => $composer_lock_path]);
-      return new CacheableJsonResponse(['error' => 'composer.lock not found'], Response::HTTP_NOT_FOUND);
-    }
-
-    $composer_lock = json_decode(file_get_contents($composer_lock_path), TRUE);
-
-    $version = $this->findPackageVersion($composer_lock, $packageName);
-
-    if ($version === NULL) {
-      return new CacheableJsonResponse(['error' => 'Package not found'], Response::HTTP_NOT_FOUND);
-    }
-
-    $data = [
-      'package' => $packageName,
-      'version' => $version,
-    ];
-
-    $this->cacheBackend->set($cid, $data);
-
+    $data = $this->systemInfoService->getPackageVersion($packageName);
     return new CacheableJsonResponse($data);
-  }
-
-  /**
-   * Finds the version of a package in the composer.lock.
-   *
-   * @param array $composer_lock
-   *   The parsed composer.lock.
-   * @param string $packageName
-   *   The name of the package to find.
-   *
-   * @return string|null
-   *   The version of the package, or null if not found.
-   */
-  private function findPackageVersion(array $composer_lock, string $packageName) {
-    foreach (['packages', 'packages-dev'] as $section) {
-      foreach ($composer_lock[$section] as $package) {
-        if ($package['name'] === $packageName) {
-          return $package['version'];
-        }
-      }
-    }
-    return NULL;
   }
 
 }

--- a/src/Controller/SystemInfoController.php
+++ b/src/Controller/SystemInfoController.php
@@ -6,6 +6,7 @@ use Drupal\Core\Cache\CacheableJsonResponse;
 use Drupal\Core\Controller\ControllerBase;
 use Drupal\tide_core\TideSystemInfoService;
 use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 
@@ -78,7 +79,7 @@ class SystemInfoController extends ControllerBase {
   public function getPackageVersion(Request $request) {
     $packageName = $request->query->get('q');
     $data = $this->systemInfoService->getPackageVersion($packageName);
-    return new CacheableJsonResponse($data);
+    return new JsonResponse($data);
   }
 
 }

--- a/src/Plugin/monitoring/SensorPlugin/TidetimesSensorPlugin.php
+++ b/src/Plugin/monitoring/SensorPlugin/TidetimesSensorPlugin.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace Drupal\tide_core\Plugin\monitoring\SensorPlugin;
+
+use Drupal\monitoring\Result\SensorResultInterface;
+use Drupal\monitoring\SensorPlugin\ExtendedInfoSensorPluginInterface;
+use Drupal\monitoring\SensorPlugin\SensorPluginBase;
+
+/**
+ * Monitors the Section API connection.
+ *
+ * @SensorPlugin(
+ *   id = "tide_times_sensor",
+ *   label = @Translation("Tide Times Sensor"),
+ *   description = @Translation("Monitors tide modules."),
+ * )
+ */
+class TidetimesSensorPlugin extends SensorPluginBase implements ExtendedInfoSensorPluginInterface {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function resultVerbose(SensorResultInterface $result) {
+    return [
+      '#type' => 'inline_template',
+      '#template' => '
+      <div class="system-info-collapsible">
+        {% for section, data in sections %}
+          <div class="collapsible-section">
+            <h3">{{ section|replace({"_": " "})|title }}</h3>
+            <div style="display: block;">
+                <ul>
+                  {% for key, value in data %}
+                    <li><strong>{{ key }}:</strong> {{ value }}</li>
+                  {% endfor %}
+                </ul>
+            </div>
+          </div>
+        {% endfor %}
+      </div>
+      
+      <style>
+        .system-info-collapsible h3 {
+          cursor: pointer;
+          background-color: #f0f0f0;
+          padding: 10px;
+          margin: 5px 0;
+        }
+        .system-info-collapsible h3:hover {
+          background-color: #e0e0e0;
+        }
+        .system-info-collapsible ul {
+          margin-left: 20px;
+        }
+      </style>
+    ',
+      '#context' => [
+        'sections' => [
+          'package_versions' => $this->getInfo()['package_versions'],
+        ],
+      ],
+    ];
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function runSensor(SensorResultInterface $sensor_result) {
+    $sensor_result->setValue(json_encode($this->getInfo(), JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE));
+  }
+
+  /**
+   * Returns package infomation for Verbose.
+   */
+  private function getInfo() {
+    $sys_info = \Drupal::service('tide_core.system_info_service');
+    $package_versions = [
+      'drupal/core' => $sys_info->getPackageVersion('drupal/core'),
+      'dpc-sdp/tide' => $sys_info->getPackageVersion('dpc-sdp/tide'),
+      'dpc-sdp/tide_core' => $sys_info->getPackageVersion('dpc-sdp/tide_core'),
+      'drush/drush' => $sys_info->getPackageVersion('drush/drush'),
+      'php' => $sys_info->getPackageVersion('php'),
+    ];
+    $context = [
+      'package_versions' => [],
+    ];
+    foreach ($package_versions as $package => $info) {
+      $context['package_versions'][$package] = $info['version'] ?? 'Unknown';
+    }
+    return $context;
+  }
+
+}

--- a/src/TideSystemInfoService.php
+++ b/src/TideSystemInfoService.php
@@ -1,0 +1,295 @@
+<?php
+
+namespace Drupal\tide_core;
+
+use Drupal\Core\Cache\CacheBackendInterface;
+use Drupal\Core\Entity\ContentEntityInterface;
+use Drupal\Core\Entity\EntityFieldManagerInterface;
+use Drupal\Core\Entity\EntityTypeBundleInfoInterface;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\File\FileSystemInterface;
+use Drupal\Core\Logger\LoggerChannelFactoryInterface;
+use Drupal\Core\State\StateInterface;
+use Drupal\monitoring\Entity\SensorConfig;
+use Drupal\monitoring\SensorRunner;
+
+/**
+ * Service for retrieving system information.
+ */
+class TideSystemInfoService {
+
+  /**
+   * CacheBackendInterface.
+   *
+   * @var \Drupal\Core\Cache\CacheBackendInterface
+   */
+  protected $cacheBackend;
+
+  /**
+   * StateInterface.
+   *
+   * @var \Drupal\Core\State\StateInterface
+   */
+  protected $state;
+
+  /**
+   * EntityTypeManagerInterface.
+   *
+   * @var \Drupal\Core\Entity\EntityTypeManagerInterface
+   */
+  protected $entityTypeManager;
+
+  /**
+   * EntityTypeBundleInfoInterface.
+   *
+   * @var \Drupal\Core\Entity\EntityTypeBundleInfoInterface
+   */
+  protected $entityTypeBundleInfo;
+
+  /**
+   * EntityFieldManagerInterface.
+   *
+   * @var \Drupal\Core\Entity\EntityFieldManagerInterface
+   */
+  protected $entityFieldManager;
+
+  /**
+   * LoggerChannelFactoryInterface.
+   *
+   * @var \Drupal\Core\Logger\LoggerChannelFactoryInterface
+   */
+  protected $logger;
+
+  /**
+   * FileSystemInterface.
+   *
+   * @var \Drupal\Core\File\FileSystemInterface
+   */
+  protected $fileSystem;
+
+  /**
+   * SensorRunner.
+   *
+   * @var \Drupal\monitoring\SensorRunner
+   */
+  protected $sensorRunner;
+
+  /**
+   * Constructs a new SystemInfoService.
+   */
+  public function __construct(
+    CacheBackendInterface $cache_backend,
+    StateInterface $state,
+    EntityTypeManagerInterface $entity_type_manager,
+    EntityTypeBundleInfoInterface $entity_type_bundle_info,
+    EntityFieldManagerInterface $entity_field_manager,
+    LoggerChannelFactoryInterface $logger,
+    FileSystemInterface $file_system,
+    SensorRunner $sensor_runner
+  ) {
+    $this->cacheBackend = $cache_backend;
+    $this->state = $state;
+    $this->entityTypeManager = $entity_type_manager;
+    $this->entityTypeBundleInfo = $entity_type_bundle_info;
+    $this->entityFieldManager = $entity_field_manager;
+    $this->logger = $logger;
+    $this->fileSystem = $file_system;
+    $this->sensorRunner = $sensor_runner;
+  }
+
+  /**
+   * Gets system information including Tide and SDP versions.
+   *
+   * @return array
+   *   An array containing Tide and SDP versions.
+   */
+  public function getSystemInfo() {
+    $cid = 'tide_core:system_info:composer_versions';
+
+    if ($cache = $this->cacheBackend->get($cid)) {
+      return $cache->data;
+    }
+
+    $composer_file_path = $this->fileSystem->realpath(DRUPAL_ROOT . '/../composer.json');
+
+    if (!file_exists($composer_file_path)) {
+      $this->logger->get('tide_core')->error('composer.json not found.');
+      return ['error' => 'composer.json not found'];
+    }
+
+    $composer_data = json_decode(file_get_contents($composer_file_path), TRUE);
+
+    $data = [
+      'tideVersion' => $composer_data['require']['dpc-sdp/tide'] ?? 'unknown',
+      'sdpVersion' => $composer_data['extra']['sdp_version'] ?? 'unknown',
+    ];
+
+    $this->cacheBackend->set($cid, $data, $this->state->get('tide_core.cache_lifetime', 3600));
+
+    return $data;
+  }
+
+  /**
+   * Gets custom field information for specified entity types.
+   *
+   * @param array $requestedTypes
+   *   Array of requested entity types or empty for all.
+   *
+   * @return array
+   *   An array of custom field IDs grouped by entity type and bundle.
+   */
+  public function getCustomFields(array $requestedTypes = []) {
+    $cid = 'tide_core:system_info:fields:' . md5(implode(',', $requestedTypes));
+
+    if ($cache = $this->cacheBackend->get($cid)) {
+      return $cache->data;
+    }
+
+    $result = [];
+    $entityTypes = $this->entityTypeManager->getDefinitions();
+
+    foreach ($entityTypes as $entityTypeId => $entityType) {
+      if (!$entityType->entityClassImplements(ContentEntityInterface::class)) {
+        continue;
+      }
+
+      if (!empty($requestedTypes) && !in_array($entityTypeId, $requestedTypes)) {
+        continue;
+      }
+
+      $result[$entityTypeId] = [];
+      $bundles = $this->entityTypeBundleInfo->getBundleInfo($entityTypeId);
+
+      foreach ($bundles as $bundleId => $bundleInfo) {
+        $result[$entityTypeId][$bundleId] = $this->getEntityCustomFields($entityTypeId, $bundleId);
+      }
+    }
+
+    $this->cacheBackend->set($cid, $result, $this->state->get('tide_core.cache_lifetime', 3600));
+
+    return $result;
+  }
+
+  /**
+   * Gets custom fields for a specific entity type and bundle.
+   *
+   * @param string $entityTypeId
+   *   The entity type ID.
+   * @param string $bundleId
+   *   The bundle ID.
+   *
+   * @return array
+   *   Array of custom field names.
+   */
+  protected function getEntityCustomFields($entityTypeId, $bundleId) {
+    $fieldDefinitions = $this->entityFieldManager->getFieldDefinitions($entityTypeId, $bundleId);
+    return array_values(array_filter(array_keys($fieldDefinitions),
+      function ($fieldName) use ($fieldDefinitions) {
+        $fieldDefinition = $fieldDefinitions[$fieldName];
+        return !$fieldDefinition->isComputed() && strpos($fieldName, 'field_') === 0;
+      }));
+  }
+
+  /**
+   * Gets all valid entity types.
+   *
+   * @return array
+   *   Array of valid entity type IDs.
+   */
+  public function getValidEntityTypes() {
+    $cid = 'tide_core:system_info:valid_entity_types';
+
+    if ($cache = $this->cacheBackend->get($cid)) {
+      return $cache->data;
+    }
+
+    $validTypes = array_keys(array_filter(
+      $this->entityTypeManager->getDefinitions(),
+      function ($entityType) {
+        return $entityType->entityClassImplements(ContentEntityInterface::class);
+      }
+    ));
+
+    $this->cacheBackend->set($cid, $validTypes, $this->state->get('tide_core.cache_lifetime', 86400));
+
+    return $validTypes;
+  }
+
+  /**
+   * Gets the version of a specified package from composer.lock.
+   *
+   * @param string $packageName
+   *   The name of the package.
+   *
+   * @return array
+   *   An array containing package name and version.
+   */
+  public function getPackageVersion($packageName) {
+    if (empty($packageName)) {
+      $result = $this->sensorRunner->runSensors([SensorConfig::load('tide_times')]);
+      $value = $result[0]->getValue();
+      $decodedValue = json_decode($value, TRUE);
+      return $decodedValue;
+    }
+
+    if (strtolower($packageName) === 'php') {
+      return [
+        'package' => 'php',
+        'version' => PHP_VERSION,
+      ];
+    }
+
+    $cid = 'tide_core:system_info:package_version:' . md5($packageName);
+
+    if ($cache = $this->cacheBackend->get($cid)) {
+      return $cache->data;
+    }
+
+    $composer_lock_path = $this->fileSystem->realpath(DRUPAL_ROOT . '/../composer.lock');
+
+    if (!file_exists($composer_lock_path)) {
+      $this->logger->get('tide_core')->error('composer.lock not found');
+      return ['error' => 'composer.lock not found'];
+    }
+
+    $composer_lock = json_decode(file_get_contents($composer_lock_path), TRUE);
+
+    $version = $this->findPackageVersion($composer_lock, $packageName);
+
+    if ($version === NULL) {
+      return ['error' => 'Package not found'];
+    }
+
+    $data = [
+      'package' => $packageName,
+      'version' => $version,
+    ];
+
+    $this->cacheBackend->set($cid, $data);
+
+    return $data;
+  }
+
+  /**
+   * Finds the version of a package in the composer.lock.
+   *
+   * @param array $composer_lock
+   *   The parsed composer.lock.
+   * @param string $packageName
+   *   The name of the package to find.
+   *
+   * @return string|null
+   *   The version of the package, or null if not found.
+   */
+  protected function findPackageVersion(array $composer_lock, string $packageName) {
+    foreach (['packages', 'packages-dev'] as $section) {
+      foreach ($composer_lock[$section] as $package) {
+        if ($package['name'] === $packageName) {
+          return $package['version'];
+        }
+      }
+    }
+    return NULL;
+  }
+
+}

--- a/tests/src/Kernel/SystemInfoControllerTest.php
+++ b/tests/src/Kernel/SystemInfoControllerTest.php
@@ -1,0 +1,152 @@
+<?php
+
+namespace Drupal\Tests\tide_core\Kernel;
+
+use Drupal\KernelTests\KernelTestBase;
+use Drupal\tide_core\Controller\SystemInfoController;
+use org\bovigo\vfs\vfsStream;
+
+/**
+ * Tests the SystemInfoController.
+ *
+ * @group tide_core
+ */
+class SystemInfoControllerTest extends KernelTestBase {
+
+  /**
+   * The modules to enable for this test.
+   *
+   * @var array
+   */
+  protected static $modules = ['system', 'user', 'field', 'tide_core'];
+
+  /**
+   * The SystemInfoController instance.
+   *
+   * @var \Drupal\tide_core\Controller\SystemInfoController
+   */
+  protected $controller;
+
+  /**
+   * The virtual file system.
+   *
+   * @var \org\bovigo\vfs\vfsStreamDirectory
+   */
+  protected $vfsRoot;
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp(): void {
+    parent::setUp();
+
+    $this->installEntitySchema('user');
+    $this->installConfig(['field']);
+
+    // Set up virtual file system.
+    $this->vfsRoot = vfsStream::setup('root');
+    vfsStream::newFile('composer.json')
+      ->at($this->vfsRoot)
+      ->setContent(json_encode([
+        'require' => ['dpc-sdp/tide' => '1.2.3'],
+        'extra' => ['sdp_version' => '4.5.6'],
+      ]));
+
+    $container = $this->container;
+
+    // Mock the file system service.
+    $file_system = $this->createMock('\Drupal\Core\File\FileSystemInterface');
+    $file_system->method('realpath')
+      ->willReturn($this->vfsRoot->url() . '/composer.json');
+    $container->set('file_system', $file_system);
+
+    $this->controller = SystemInfoController::create($container);
+  }
+
+  /**
+   * Tests the getSystemInfo method.
+   */
+  public function testGetSystemInfo() {
+    $response = $this->controller->getSystemInfo();
+    $this->assertTrue($response->isOk());
+
+    $content = json_decode($response->getContent(), TRUE);
+    $this->assertEquals('1.2.3', $content['tideVersion']);
+    $this->assertEquals('4.5.6', $content['sdpVersion']);
+
+    // Test caching.
+    $cachedResponse = $this->controller->getSystemInfo();
+    $this->assertEquals($response->getContent(), $cachedResponse->getContent());
+  }
+
+  /**
+   * Tests the getFields method with valid input.
+   */
+  public function testGetFieldsValidInput() {
+    $response = $this->controller->getFields('user');
+    $this->assertTrue($response->isOk());
+
+    $content = json_decode($response->getContent(), TRUE);
+    $this->assertArrayHasKey('user', $content);
+    $this->assertArrayHasKey('user', $content['user']);
+
+    // Test caching.
+    $cachedResponse = $this->controller->getFields('user');
+    $this->assertEquals($response->getContent(), $cachedResponse->getContent());
+  }
+
+  /**
+   * Tests the getFields method with invalid input.
+   */
+  public function testGetFieldsInvalidInput() {
+    $response = $this->controller->getFields('invalid_entity_type');
+    $this->assertEquals(400, $response->getStatusCode());
+
+    $content = json_decode($response->getContent(), TRUE);
+    $this->assertArrayHasKey('error', $content);
+    $this->assertArrayHasKey('valid_types', $content);
+  }
+
+  /**
+   * Tests the getFields method with 'all' input.
+   */
+  public function testGetFieldsAllInput() {
+    $response = $this->controller->getFields('all');
+    $this->assertTrue($response->isOk());
+
+    $content = json_decode($response->getContent(), TRUE);
+    $this->assertArrayHasKey('user', $content);
+  }
+
+  /**
+   * Tests error handling when composer.json is not found.
+   */
+  public function testComposerJsonNotFound() {
+    // Remove the virtual composer.json file.
+    unlink($this->vfsRoot->url() . '/composer.json');
+
+    $response = $this->controller->getSystemInfo();
+    $this->assertEquals(404, $response->getStatusCode());
+
+    $content = json_decode($response->getContent(), TRUE);
+    $this->assertArrayHasKey('error', $content);
+  }
+
+  /**
+   * Tests the getValidEntityTypes method indirectly.
+   */
+  public function testGetValidEntityTypes() {
+    $response = $this->controller->getFields('all');
+    $content = json_decode($response->getContent(), TRUE);
+
+    // 'user' should always be a valid entity type
+    $this->assertArrayHasKey('user', $content);
+
+    // Test with an invalid entity type.
+    $response = $this->controller->getFields('invalid_type');
+    $content = json_decode($response->getContent(), TRUE);
+    $this->assertArrayHasKey('valid_types', $content);
+    $this->assertContains('user', $content['valid_types']);
+  }
+
+}

--- a/tests/src/Kernel/SystemInfoControllerTest.php
+++ b/tests/src/Kernel/SystemInfoControllerTest.php
@@ -5,7 +5,6 @@ namespace Drupal\Tests\tide_core\Kernel;
 use Drupal\KernelTests\KernelTestBase;
 use Drupal\test_helpers\TestHelpers;
 use Drupal\tide_core\Controller\SystemInfoController;
-use Drupal\tide_core\TideSystemInfoService;
 use org\bovigo\vfs\vfsStream;
 
 /**
@@ -36,6 +35,11 @@ class SystemInfoControllerTest extends KernelTestBase {
    */
   protected $vfsRoot;
 
+  /**
+   * Tide_core system_info_service.
+   *
+   * @var \Drupal\tide_core\TideSystemInfoService
+   */
   protected $sysInfoService;
 
   /**
@@ -57,7 +61,6 @@ class SystemInfoControllerTest extends KernelTestBase {
       ]));
 
     $container = $this->container;
-
 
     // Mock the file system service.
     $file_system = $this->createMock('\Drupal\Core\File\FileSystemInterface');

--- a/tide_core.info.yml
+++ b/tide_core.info.yml
@@ -37,6 +37,7 @@ dependencies:
   - drupal:views
   - drupal:views_data_export
   - drupal:workflows
+  - monitoring:monitoring
   - editor_advanced_link:editor_advanced_link
   - entity_browser:entity_browser
   - entity_browser:entity_browser_entity_form

--- a/tide_core.install
+++ b/tide_core.install
@@ -236,3 +236,18 @@ function tide_core_update_10007() {
   // Enable Tide TFA.
   $tideCoreOperation->enabledTideTfa();
 }
+
+/**
+ * Installs tide_times sensor.
+ */
+function tide_core_update_10008() {
+  \Drupal::moduleHandler()->loadInclude('tide_core', 'inc', 'includes/helpers');
+  $config_location = [\Drupal::service('extension.list.module')->getPath('tide_core') . '/config/install'];
+  $config_read = _tide_read_config('monitoring.sensor_config.tide_times', $config_location, TRUE);
+  $storage = \Drupal::entityTypeManager()->getStorage('monitoring_sensor_config');
+  $id = $storage->getIDFromConfigName('monitoring.sensor_config.tide_times', $storage->getEntityType()->getConfigPrefix());
+  if ($storage->load($id) == NULL) {
+    $config_entity = $storage->createFromStorageRecord($config_read);
+    $config_entity->save();
+  }
+}

--- a/tide_core.routing.yml
+++ b/tide_core.routing.yml
@@ -18,7 +18,21 @@ tide_core.system_info:
   path: '/api/v1/system-info'
   defaults:
     _controller: '\Drupal\tide_core\Controller\SystemInfoController::getSystemInfo'
-    _title: 'System Info'
+    _title: 'System Information'
   methods: ['GET']
   requirements:
     _access: 'TRUE'
+
+tide_core.system_info.fields:
+  path: '/api/v1/system-info/fields/{types}'
+  defaults:
+    _controller: '\Drupal\tide_core\Controller\SystemInfoController::getFields'
+    _title: 'System Fields Information'
+    types: 'all'
+  requirements:
+    _access: 'TRUE'
+  options:
+    no_cache: 'TRUE'
+    parameters:
+      types:
+        type: string

--- a/tide_core.routing.yml
+++ b/tide_core.routing.yml
@@ -36,3 +36,12 @@ tide_core.system_info.fields:
     parameters:
       types:
         type: string
+
+tide_core.package_version:
+  path: '/api/v1/package-version'
+  defaults:
+    _controller: '\Drupal\tide_core\Controller\SystemInfoController::getPackageVersion'
+    _title: 'Package Version Information'
+  methods: ['GET']
+  requirements:
+    _access: 'TRUE'

--- a/tide_core.routing.yml
+++ b/tide_core.routing.yml
@@ -14,17 +14,8 @@ tide_core.node.action_confirm:
   requirements:
     _custom_access: '\Drupal\tide_core\Form\NodeActionForm::access'
 
-tide_core.system_info:
-  path: '/api/v1/system-info'
-  defaults:
-    _controller: '\Drupal\tide_core\Controller\SystemInfoController::getSystemInfo'
-    _title: 'System Information'
-  methods: ['GET']
-  requirements:
-    _access: 'TRUE'
-
-tide_core.system_info.fields:
-  path: '/api/v1/system-info/fields/{types}'
+tide_core.fields_info.fields:
+  path: '/fields-info/{types}'
   defaults:
     _controller: '\Drupal\tide_core\Controller\SystemInfoController::getFields'
     _title: 'System Fields Information'
@@ -38,7 +29,7 @@ tide_core.system_info.fields:
         type: string
 
 tide_core.package_version:
-  path: '/api/v1/package-version'
+  path: '/pkg-version'
   defaults:
     _controller: '\Drupal\tide_core\Controller\SystemInfoController::getPackageVersion'
     _title: 'Package Version Information'

--- a/tide_core.routing.yml
+++ b/tide_core.routing.yml
@@ -29,10 +29,10 @@ tide_core.system_info.fields:
     _controller: '\Drupal\tide_core\Controller\SystemInfoController::getFields'
     _title: 'System Fields Information'
     types: 'all'
+  methods: ['GET']
   requirements:
     _access: 'TRUE'
   options:
-    no_cache: 'TRUE'
     parameters:
       types:
         type: string

--- a/tide_core.routing.yml
+++ b/tide_core.routing.yml
@@ -13,3 +13,12 @@ tide_core.node.action_confirm:
     _title_callback: '\Drupal\tide_core\Form\NodeActionForm::getTitle'
   requirements:
     _custom_access: '\Drupal\tide_core\Form\NodeActionForm::access'
+
+tide_core.system_info:
+  path: '/api/v1/system-info'
+  defaults:
+    _controller: '\Drupal\tide_core\Controller\SystemInfoController::getSystemInfo'
+    _title: 'System Info'
+  methods: ['GET']
+  requirements:
+    _access: 'TRUE'

--- a/tide_core.services.yml
+++ b/tide_core.services.yml
@@ -16,3 +16,14 @@ services:
     arguments: ['@plugin.manager.entity_reference_selection']
   tide_core.common_services:
     class: Drupal\tide_core\TideCommonServices
+  tide_core.system_info_service:
+    class: Drupal\tide_core\TideSystemInfoService
+    arguments:
+      - '@cache.default'
+      - '@state'
+      - '@entity_type.manager'
+      - '@entity_type.bundle.info'
+      - '@entity_field.manager'
+      - '@logger.factory'
+      - '@file_system'
+      - '@monitoring.sensor_runner'


### PR DESCRIPTION
### Jira
https://digital-vic.atlassian.net/browse/SD-188

### Problem/Motivation
> As a tester,
I want to be able to get the Tide package version and SDP version via an API,
So that I know what versions have been deployed on different environments for release management and visibility

### Fix
~Apart from `/api/v1/system-info`, `/api/v1/system-info/fields/{types}` has also been introduced to better explain the back-end compatibility.~

/pkg-version
```json
{
    "package_versions": {
        "drupal/core": "10.3.5",
        "dpc-sdp/tide": "dev-mono-repo-test",
        "dpc-sdp/tide_core": "dev-feature/SD-268-mono-repo-phase-1",
        "drush/drush": "12.5.3",
        "php": "8.3.10"
    }
}
```
/fields-info
/fields-info/node
/fields-info/node,media

```
{
    "media": {
        "audio": [
            "field_license_type",
            "field_media_audience",
            "field_media_department",
            "field_media_file",
            "field_media_length",
            "field_media_show_transcript",
            "field_media_site",
            "field_media_summary",
            "field_media_topic",
            "field_media_transcript"
        ],
.
.
.
.
.
```
/pkg-version?q=drush/drush
```
{
    "package": "drush/drush",
    "version": "12.5.3"
}
```
/pkg-version?q=dpc-sdp/tide_core

```
{
    "package": "dpc-sdp/tide_core",
    "version": "dev-reference"
}
```
/pkg-version?q=php
```
{
    "package": "php",
    "version": "8.3.9"
}
```
/pkg-version?q=drupal/core
```
{
    "package": "drupal/core",
    "version": "10.2.5"
}


