### PR TITLE
Added code clean up and remove tfa enable with hook.

### DIFF
--- a/modules/tide_landing_page/tide_landing_page.module
+++ b/modules/tide_landing_page/tide_landing_page.module
@@ -109,11 +109,6 @@ function tide_landing_page_form_node_form_alter(&$form, FormStateInterface $form
       }
     }
 
-    // Adding custom states from webform js.
-    if (\Drupal::moduleHandler()->moduleExists('webform')) {
-      $form['#attached']['library'][] = 'webform/webform.states';
-    }
-
     // Hide the field Show Acknowledgement to Country if tide_site is missing.
     if (!\Drupal::moduleHandler()->moduleExists('tide_site')) {
       $form['field_show_ack_of_country']['#attributes']['class'][] = 'hidden';

--- a/tide_core.install
+++ b/tide_core.install
@@ -54,9 +54,6 @@ function tide_core_install() {
 
   // Changes the diff modules general_settings.revision_pager_limit to 16.
   $tideCoreOperation->changeDiffSettings();
-
-  // Enable Tide TFA.
-  $tideCoreOperation->enabledTideTfa();
 }
 
 /**
@@ -228,19 +225,9 @@ function _tide_core_replace_attribute_in_tag($array, $tagName, $attribute, $newA
 }
 
 /**
- * Enable Tide TFA.
- */
-function tide_core_update_10007() {
-  $tideCoreOperation = new TideCoreOperation();
-
-  // Enable Tide TFA.
-  $tideCoreOperation->enabledTideTfa();
-}
-
-/**
  * Installs tide_times sensor.
  */
-function tide_core_update_10008() {
+function tide_core_update_10007() {
   \Drupal::moduleHandler()->loadInclude('tide_core', 'inc', 'includes/helpers');
   $config_location = [\Drupal::service('extension.list.module')->getPath('tide_core') . '/config/install'];
   $config_read = _tide_read_config('monitoring.sensor_config.tide_times', $config_location, TRUE);


### PR DESCRIPTION
### Jira

### Problem/Motivation
There is currently a conflict between the TFA password reset and the [PRLP](https://www.drupal.org/project/prlp) module. We need an SDP-specific patch to ensure the PRLP password reset functions correctly with TFA. Without this patch, the TFA module bypasses the PRLP service and instead calls Drupal core's default password reset service.

### Fix
1. We will stop auto-enabling the tide_tfa module for all projects. Although the TFA code works as expected, we will only enable it on a project-by-project basis after implementing the SDP-specific patch that resolves the password reset issue. This will ensure proper integration between TFA and PRLP.

2. Removed duplicate sate js addition in landing page module as that addition is moved to tide_core.module.

### Related PRs

### Screenshots

### TODO
