### PR TITLE
[SD-356]added content category to publication page

### DIFF
--- a/modules/tide_publication/config/install/core.entity_view_display.node.publication_page.default.yml
+++ b/modules/tide_publication/config/install/core.entity_view_display.node.publication_page.default.yml
@@ -2,6 +2,7 @@ langcode: en
 status: true
 dependencies:
   config:
+    - field.field.node.publication.field_content_category
     - field.field.node.publication_page.field_landing_page_component
     - field.field.node.publication_page.field_landing_page_contact
     - field.field.node.publication_page.field_landing_page_hero_image
@@ -22,6 +23,7 @@ dependencies:
     - entity_reference_revisions
     - options
     - user
+    - term_reference_tree
 id: node.publication_page.default
 targetEntityType: node
 bundle: publication_page
@@ -39,6 +41,17 @@ content:
     region: content
     settings: {  }
     third_party_settings: {  }
+  field_content_category:
+    type: term_reference_tree
+    weight: 5
+    region: content
+    settings:
+      start_minimized: true
+      leaves_only: true
+      select_parents: false
+      cascading_selection: 0
+      max_depth: 0
+    third_party_settings: { }
   field_landing_page_component:
     weight: 1
     label: above

--- a/modules/tide_publication/config/install/field.field.node.publication_page.field_content_category.yml
+++ b/modules/tide_publication/config/install/field.field.node.publication_page.field_content_category.yml
@@ -1,0 +1,28 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_content_category
+    - node.type.publication_page
+    - taxonomy.vocabulary.content_category
+id: node.publication_page.field_content_category
+field_name: field_content_category
+entity_type: node
+bundle: publication_page
+label: 'Content category'
+description: 'Select the most relevant option from the <a href="https://www.vic.gov.au/content-categories">list of content categories</a>. This mandatory field will help with search and filtering on the website.'
+required: true
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:taxonomy_term'
+  handler_settings:
+    target_bundles:
+      content_category: content_category
+    sort:
+      field: name
+      direction: asc
+    auto_create: false
+    auto_create_bundle: ''
+field_type: entity_reference

--- a/modules/tide_publication/tests/behat/features/fields.feature
+++ b/modules/tide_publication/tests/behat/features/fields.feature
@@ -179,3 +179,5 @@ Feature: Fields for Publication content type
     And I see field "Show content rating?"
     And I should see an "input#edit-field-show-content-rating-value" element
     And I should not see an "input#edit-field-show-content-rating-value.required" element
+
+    And I should see text matching "Content category"

--- a/modules/tide_publication/tide_publication.install
+++ b/modules/tide_publication/tide_publication.install
@@ -130,3 +130,21 @@ function tide_publication_update_10004() {
   $tide_update_helper = \Drupal::service('tide_core.entity_update_helper');
   $tide_update_helper->configMergeDeep('tide_landing_page', TideEntityUpdateHelper::INSTALL_DIR, $form_configs);
 }
+
+
+/**
+ * Imports publication_page.field_content_category for existing sites.
+ */
+function tide_publication_update_10005() {
+  \Drupal::moduleHandler()->loadInclude('tide_core', 'inc', 'includes/helpers');
+  $config_location = [\Drupal::service('extension.list.module')->getPath('tide_publication') . '/config/install'];
+  $config_read = _tide_read_config('field.field.node.publication_page.field_content_category', $config_location, TRUE);
+  $storage = \Drupal::entityTypeManager()->getStorage('field_config');
+  $id = $storage->getIDFromConfigName('field.field.node.publication_page.field_content_category', $storage->getEntityType()->getConfigPrefix());
+  if ($storage->load($id) == NULL) {
+    $config_entity = $storage->createFromStorageRecord($config_read);
+    $config_entity->save();
+  }
+  \Drupal::moduleHandler()->loadInclude('tide_core', 'inc', 'includes/updates');
+  _tide_core_content_category_form_display('publication_page');
+}

--- a/modules/tide_publication/tide_publication.install
+++ b/modules/tide_publication/tide_publication.install
@@ -131,7 +131,6 @@ function tide_publication_update_10004() {
   $tide_update_helper->configMergeDeep('tide_landing_page', TideEntityUpdateHelper::INSTALL_DIR, $form_configs);
 }
 
-
 /**
  * Imports publication_page.field_content_category for existing sites.
  */


### PR DESCRIPTION
### Jira
https://digital-vic.atlassian.net/browse/SD-356
Testing link: https://nginx-php.pr-454.content-reference-sdp-vic-gov-au.sdp4.sdp.vic.gov.au/
### Problem/Motivation
Content category section not available on publication page content type
### Fix
Added content category field to publication page.
### Related PRs

### Screenshots
![Screenshot 2024-10-15 at 4 55 42 pm](https://github.com/user-attachments/assets/2ba8c8e8-8bfa-4845-8997-20318bddddf9)

### TODO
