### PR TITLE
Updated function to be compatible with the base one.

### DIFF
--- a/modules/tide_site/src/Plugin/Linkit/Substitution/Canonical.php
+++ b/modules/tide_site/src/Plugin/Linkit/Substitution/Canonical.php
@@ -67,9 +67,9 @@ class Canonical extends LinkitCanonical implements ContainerFactoryPluginInterfa
   /**
    * {@inheritdoc}
    */
-  public function getUrl(EntityInterface $entity) {
+  public function getUrl(EntityInterface $entity, array $options = []) {
     /** @var \Drupal\Core\GeneratedUrl $url */
-    $url = parent::getUrl($entity)->toString(TRUE);
+    $url = parent::getUrl($entity, $options)->toString(TRUE);
 
     // Remove the site prefix from path alias when responding from
     // JSONAPI entity resource with site parameter.


### PR DESCRIPTION
### Jira

### Problem/Motivation
`PHP Fatal error:  Declaration of Drupal\tide_site\Plugin\Linkit\Substitution\Canonical::getUrl(Drupal\Core\Entity\EntityInterface $entity) must be compatible with Drupal\linkit\Plugin\Linkit\Substitution\Canonical::getUrl(Drupal\Core\Entity\EntityInterface $entity, array $options = []) in /app/docroot/modules/contrib/tide_core/modules/tide_site/src/Plugin/Linkit/Substitution/Canonical.php on line 70`
### Fix
Updated the overriding function.
### Related PRs
It is related to the latest linkit module release and this patch to be specific which updates the getUrl function - https://www.drupal.org/project/linkit/issues/3022261
### Screenshots

### TODO
