### PR TITLE
Added hook dependency and updated config location.

### DIFF
--- a/modules/tide_site/tide_site.install
+++ b/modules/tide_site/tide_site.install
@@ -25,7 +25,7 @@ function tide_site_install() {
  */
 function tide_site_update_10001() {
   \Drupal::moduleHandler()->loadInclude('tide_core', 'inc', 'includes/helpers');
-  $config_location = [\Drupal::service('extension.list.module')->getPath('tide_site') . '/config/install'];
+  $config_location = [\Drupal::service('extension.list.module')->getPath('tide_core') . '/config/install'];
 
   $configs = [
     'field.storage.taxonomy_term.field_additional_comment' => 'field_storage_config',

--- a/tide_core.install
+++ b/tide_core.install
@@ -63,6 +63,16 @@ function tide_core_install() {
 }
 
 /**
+ * Implements hook_update_dependencies().
+ */
+function tide_core_update_dependencies() {
+  $dependencies = [];
+  $dependencies['tide_core'][10007] = ['bay_platform_dependencies' => 10003];
+
+  return $dependencies;
+}
+
+/**
  * Increase character limit of URLs.
  */
 function tide_core_update_10000() {


### PR DESCRIPTION
### Jira

### Problem/Motivation
1. After moving to mono repo, the cofig location change and causing issues for the sites that are behind few releases.
2. The sites that are behind few releases, the update hook creates dependencies cause the module enabled in one release and fields updated in the next one
### Fix
1. Updated config location
2. Updated hook dependencies.
### Related PRs

### Screenshots

### TODO
