### PR TITLE
Fixed PHP warning for accessing array offset on null

### DIFF
--- a/modules/tide_api/src/Plugin/jsonapi/FieldEnhancer/YamlEnhancer.php
+++ b/modules/tide_api/src/Plugin/jsonapi/FieldEnhancer/YamlEnhancer.php
@@ -23,14 +23,12 @@ class YamlEnhancer extends ResourceFieldEnhancerBase {
    */
   protected function doUndoTransform($data, Context $context) {
     $data = Yaml::decode($data);
-    $markup_text = $data['markup']['#markup'];
-    $processed_text = $data['processed_text']['#text'];
-
-    if (!empty($processed_text)) {
-      $data['processed_text']['#text'] = $this->processText($processed_text);
+    
+    if (!empty($data['markup']['#markup'])) {
+      $data['processed_text']['#text'] = $this->processText($data['markup']['#markup']);
     }
-    if (!empty($markup_text)) {
-      $data['markup']['#markup'] = $this->processText($markup_text);
+    if (!empty($data['markup']['#markup'])) {
+      $data['markup']['#markup'] = $this->processText($data['markup']['#markup']);
     }
 
     return $data;


### PR DESCRIPTION
### Problem/Motivation

Logs are full of errors such as these
```
Warning: Trying to access array offset on null in Drupal\\tide_api\\Plugin\\jsonapi\\FieldEnhancer\\YamlEnhancer->doUndoTransform() (line 27 of /app/docroot/modules/contrib/tide_core/modules/tide_api/src/Plugin/jsonapi/FieldEnhancer/YamlEnhancer.php) #0 /app/docroot/core/includes/bootstrap.inc(166): _drupal_error_handler_real()
#1 /app/docroot/modules/contrib/tide_core/modules/tide_api/src/Plugin/jsonapi/FieldEnhancer/YamlEnhancer.php(27): _drupal_error_handler()
#2 /app/vendor/e0ipso/shaper/src/DataAdaptor/DataAdaptorTransformerTrait.php(57): Drupal\\tide_api\\Plugin\\jsonapi\\FieldEnhancer\\YamlEnhancer->doUndoTransform()
#3 /app/docroot/modules/contrib/jsonapi_extras/src/Normalizer/ResourceObjectNormalizer.php(56): Drupal\\jsonapi_extras\\Plugin\\ResourceFieldEnhancerBase->undoTransform()
...
```
and
```
Warning: Undefined array key "processed_text" in Drupal\tide_api\Plugin\jsonapi\FieldEnhancer\YamlEnhancer->doUndoTransform()
```
and
```
Warning: Undefined array key "markup" in Drupal\tide_api\Plugin\jsonapi\FieldEnhancer\YamlEnhancer->doUndoTransform()
```

### Fix

Removed interim variable assignments which, while somewhat improving readability, does not impact the function at all.