### PR TITLE
lock scheduled_transitions to 2.5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -69,7 +69,7 @@
         "drupal/viewsreference": "^2.0@beta",
         "drupal/workbench": "^1.4",
         "drupal/dynamic_entity_reference": "^3.0",
-        "drupal/scheduled_transitions": "^2.3",
+        "drupal/scheduled_transitions": "2.5",
         "drupal/link_field_autocomplete_filter": "^2.0",
         "drupal/queue_mail": "^1.5",
         "drupal/token": "^1.15",


### PR DESCRIPTION
During the release, discovered that the "Add pagination to target revision candidates list" patch for `scheduled_transitions` is no longer compatible. Considering the size of the patch, re-rolling is not attempted for now, so, temporarily lock `scheduled_transitions` module version to `2.5` to proceed with the release.

follow up https://digital-vic.atlassian.net/browse/SD-534