### PR TITLE
[SD-22] Updated hero theme image

### DIFF
--- a/modules/tide_landing_page/config/install/field.field.node.landing_page.field_landing_page_hero_theme.yml
+++ b/modules/tide_landing_page/config/install/field.field.node.landing_page.field_landing_page_hero_theme.yml
@@ -10,9 +10,9 @@ id: node.landing_page.field_landing_page_hero_theme
 field_name: field_landing_page_hero_theme
 entity_type: node
 bundle: landing_page
-label: Here image theme
+label: Hero image theme
 description: 'If your hero image is mostly dark, apply the dark theme. This changes how the page title is displayed.'
-required: false
+required: true
 translatable: false
 default_value: {  }
 default_value_callback: ''

--- a/modules/tide_landing_page/js/hero_image_theme.js
+++ b/modules/tide_landing_page/js/hero_image_theme.js
@@ -1,0 +1,38 @@
+(function (Drupal) {
+  "use strict";
+
+  Drupal.behaviors.heroImageTheme = {
+    attach: function (context, settings) {
+      const imageTheme = context.querySelector(
+        'select[data-drupal-selector^="edit-field-landing-page-hero-theme"]'
+      );
+
+      if (imageTheme !== null) {
+        setImageTheme();
+
+        const headerStyles = context.querySelectorAll(
+          'input[data-drupal-selector^="edit-header-style-options"]'
+        );
+
+        if (headerStyles.length > 0) {
+          headerStyles.forEach((style) => {
+            style.addEventListener("change", setImageTheme);
+          });
+        }
+      }
+
+      function setImageTheme() {
+        const selectedHeaderStyle = document.querySelector(
+          'input[data-drupal-selector^="edit-header-style-options"]:checked'
+        );
+
+        if (!selectedHeaderStyle) {
+          return; // Exit if no style option is selected.
+        }
+
+        let defaultHeaderStyle = selectedHeaderStyle.value;
+        imageTheme.disabled = defaultHeaderStyle === "corner" ? false : true;
+      }
+    },
+  };
+})(Drupal);

--- a/modules/tide_landing_page/js/hero_image_theme.js
+++ b/modules/tide_landing_page/js/hero_image_theme.js
@@ -32,6 +32,8 @@
 
         let defaultHeaderStyle = selectedHeaderStyle.value;
         imageTheme.disabled = defaultHeaderStyle === "corner" ? false : true;
+        imageTheme.value =
+          defaultHeaderStyle === "fullwidth" ? "dark" : "light";
       }
     },
   };

--- a/modules/tide_landing_page/tests/behat/features/fields.feature
+++ b/modules/tide_landing_page/tests/behat/features/fields.feature
@@ -27,6 +27,7 @@ Feature: Fields for Landing Page content type
     And I should see text matching "Call to action banner"
     And I should see text matching "No Hero Banner with CTA added yet."
     And I should see the button "Add Hero banner with CTA" in the "content" region
+    And I should see a "select#edit-field-landing-page-hero-theme" element
 
     And the "#edit-field-landing-page-hero-logo" element should contain "Logo"
     And I should see an "input#edit-field-landing-page-hero-logo-entity-browser-entity-browser-open-modal" element
@@ -34,6 +35,7 @@ Feature: Fields for Landing Page content type
     And I select the radio button "Corner graphics"
     And the "#edit-field-bottom-graphical-image" element should contain "Bottom Corner Graphic"
     And I should see an "input#edit-field-bottom-graphical-image-entity-browser-target" element
+    And I should see a "select#edit-field-landing-page-hero-theme" element
 
     And I click on the horizontal tab "Header extras"
     And I should see text matching "Header components"
@@ -156,6 +158,7 @@ Feature: Fields for Landing Page content type
     And I should see text matching "Call to action banner"
     And I should see text matching "No Hero Banner with CTA added yet."
     And I should see the button "Add Hero banner with CTA" in the "content" region
+    And I should see a "select#edit-field-landing-page-hero-theme" element
 
     And the "#edit-field-landing-page-hero-logo" element should contain "Logo"
     And I should see an "input#edit-field-landing-page-hero-logo-entity-browser-entity-browser-open-modal" element
@@ -163,6 +166,7 @@ Feature: Fields for Landing Page content type
     And I select the radio button "Corner graphics"
     And the "#edit-field-bottom-graphical-image" element should contain "Bottom Corner Graphic"
     And I should see an "input#edit-field-bottom-graphical-image-entity-browser-target" element
+    And I should see a "select#edit-field-landing-page-hero-theme" element
 
     And I click on the horizontal tab "Header extras"
     And I should see text matching "Header components"
@@ -299,4 +303,48 @@ Feature: Fields for Landing Page content type
     And I wait for 5 seconds
     # This field can be "seen" but not visible.
     And I see field "field_landing_page_component[0][subform][field_customise][value]"
+    And save screenshot
+
+@api @javascript
+  Scenario: Selecting Corner graphics value from header style.
+    Given I am logged in as a user with the "editor" role
+    When I visit "node/add/landing_page"
+    And I click on the horizontal tab "Customised Header"
+    Then I should see an "#edit-header-style-options-corner" element
+    And I select "corner" from "edit-header-style-options-corner"
+    Then I should see an "#edit-field-landing-page-hero-theme" element
+    And I should see text matching "Light"
+    And save screenshot
+
+ @api @javascript
+  Scenario: Selecting Default appearance value from header style.
+    Given I am logged in as a user with the "editor" role
+    When I visit "node/add/landing_page"
+    And I click on the horizontal tab "Customised Header"
+    Then I should see an "#edit-header-style-options-default" element
+    And I select "corner" from "edit-header-style-options-default"
+    Then I should see an "#edit-field-landing-page-hero-theme" element
+    And I should see text matching "Light"
+    And save screenshot
+
+@api @javascript
+  Scenario: Selecting Full-width background image value from header style.
+    Given I am logged in as a user with the "editor" role
+    When I visit "node/add/landing_page"
+    And I click on the horizontal tab "Customised Header"
+    Then I should see an "#edit-header-style-options-fullwidtht" element
+    And I select "corner" from "edit-header-style-options-fullwidth"
+    Then I should see an "#edit-field-landing-page-hero-theme" element
+    And I should see text matching "Dark"
+    And save screenshot
+
+@api @javascript
+  Scenario: Selecting Call to action banner value from header style.
+    Given I am logged in as a user with the "editor" role
+    When I visit "node/add/landing_page"
+    And I click on the horizontal tab "Customised Header"
+    Then I should see an "#edit-header-style-options-cta" element
+    And I select "corner" from "edit-header-style-options-cta"
+    Then I should see an "#edit-field-landing-page-hero-theme" element
+    And I should see text matching "Light"
     And save screenshot

--- a/modules/tide_landing_page/tide_landing_page.install
+++ b/modules/tide_landing_page/tide_landing_page.install
@@ -203,3 +203,24 @@ function tide_landing_page_update_10107() {
   $tide_update_helper = \Drupal::service('tide_core.entity_update_helper');
   $tide_update_helper->revert('field_config', 'paragraph.key_journeys.field_paragraph_title');
 }
+
+/**
+ * Set field `field_landing_page_hero_theme` to mandatory.
+ */
+function tide_landing_page_update_10108() {
+  $bundles = [
+    'landing_page',
+    'publication',
+    'publication_page',
+  ];
+
+  foreach ($bundles as $bundle) {
+    $field = FieldConfig::loadByName('node', $bundle, 'field_landing_page_hero_theme');
+    if (!empty($field)) {
+      $field->setLabel('Hero image theme');
+      $field->setRequired(TRUE);
+      $field->setDefaultValue('light');
+      $field->save();
+    }
+  }
+}

--- a/modules/tide_landing_page/tide_landing_page.libraries.yml
+++ b/modules/tide_landing_page/tide_landing_page.libraries.yml
@@ -5,5 +5,6 @@ landing_page_form:
   js:
     js/hide_elements.js: {}
     js/statistics_grid.js: {}
+    js/hero_image_theme.js: {}
   dependencies:
     - core/jquery

--- a/modules/tide_landing_page/tide_landing_page.module
+++ b/modules/tide_landing_page/tide_landing_page.module
@@ -5,7 +5,9 @@
  * Tide Landing Page module functionality.
  */
 
-use Drupal\Core\Cache\Cache;
+use Drupal\Core\Ajax\AjaxResponse;
+use Drupal\Core\Ajax\InvokeCommand;
+ use Drupal\Core\Cache\Cache;
 use Drupal\Core\Field\WidgetBase;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Render\Element;
@@ -372,6 +374,34 @@ function tide_landing_page_field_widget_single_element_paragraphs_form_alter(&$e
 }
 
 /**
+ * Function to set value to Hero image theme.
+ *
+ * @param array $form
+ *   The form.
+ * @param Drupal\Core\Form\FormStateInterface $form_state
+ *   The form state.
+ *
+ * @return Drupal\Core\Ajax\AjaxResponse
+ *   The response.
+ */
+function tide_landing_page_set_value_hero_image_theme(array $form, FormStateInterface $form_state): AjaxResponse {
+  $response = new AjaxResponse();
+  $value = $form_state->getValue('_header_style_options');
+  if ($value === 'fullwidth') {
+    return $response->addCommand(new InvokeCommand(
+      '#edit-field-landing-page-hero-theme',
+      'val',
+      ['dark']
+    ));
+  }
+  return $response->addCommand(new InvokeCommand(
+    '#edit-field-landing-page-hero-theme',
+    'val',
+    ['light']
+  ));
+}
+
+/**
  * Node form #process callback.
  *
  * @param array $form
@@ -405,14 +435,18 @@ function _tide_landing_page_form_node_form_process(array $form, FormStateInterfa
       'corner' => t('Corner graphics'),
       'cta' => t('Call to action banner'),
     ],
+    '#ajax' => [
+      'callback' => 'tide_landing_page_set_value_hero_image_theme',
+    ],
   ];
-
-  $form['field_landing_page_hero_image']['#states']['visible'] = [
+  $form['field_landing_page_hero_image']['widget']['field_landing_page_hero_theme']['#states']['disabled'] = [
     ':input[name="_header_style_options"]' => [
+      ['value' => 'default'],
       ['value' => 'fullwidth'],
       ['value' => 'cta'],
     ],
   ];
+
   $form['field_graphical_image']['#states']['visible'] = [
     ':input[name="_header_style_options"]' => ['value' => 'corner'],
   ];

--- a/modules/tide_landing_page/tide_landing_page.module
+++ b/modules/tide_landing_page/tide_landing_page.module
@@ -414,6 +414,13 @@ function _tide_landing_page_form_node_form_process(array $form, FormStateInterfa
     ],
   ];
 
+  $form['field_landing_page_hero_image']['#states']['visible'] = [
+    ':input[name="_header_style_options"]' => [
+      ['value' => 'fullwidth'],
+      ['value' => 'cta'],
+    ],
+  ];
+
   $form['field_graphical_image']['#states']['visible'] = [
     ':input[name="_header_style_options"]' => ['value' => 'corner'],
   ];

--- a/modules/tide_landing_page/tide_landing_page.module
+++ b/modules/tide_landing_page/tide_landing_page.module
@@ -5,8 +5,6 @@
  * Tide Landing Page module functionality.
  */
 
-use Drupal\Core\Ajax\AjaxResponse;
-use Drupal\Core\Ajax\InvokeCommand;
 use Drupal\Core\Cache\Cache;
 use Drupal\Core\Field\WidgetBase;
 use Drupal\Core\Form\FormStateInterface;
@@ -374,34 +372,6 @@ function tide_landing_page_field_widget_single_element_paragraphs_form_alter(&$e
 }
 
 /**
- * Function to set value to Hero image theme.
- *
- * @param array $form
- *   The form.
- * @param Drupal\Core\Form\FormStateInterface $form_state
- *   The form state.
- *
- * @return Drupal\Core\Ajax\AjaxResponse
- *   The response.
- */
-function tide_landing_page_set_value_hero_image_theme(array $form, FormStateInterface $form_state): AjaxResponse {
-  $response = new AjaxResponse();
-  $value = $form_state->getValue('_header_style_options');
-  if ($value === 'fullwidth') {
-    return $response->addCommand(new InvokeCommand(
-      '#edit-field-landing-page-hero-theme',
-      'val',
-      ['dark']
-    ));
-  }
-  return $response->addCommand(new InvokeCommand(
-    '#edit-field-landing-page-hero-theme',
-    'val',
-    ['light']
-  ));
-}
-
-/**
  * Node form #process callback.
  *
  * @param array $form
@@ -434,9 +404,6 @@ function _tide_landing_page_form_node_form_process(array $form, FormStateInterfa
       'fullwidth' => t('Full-width  background image'),
       'corner' => t('Corner graphics'),
       'cta' => t('Call to action banner'),
-    ],
-    '#ajax' => [
-      'callback' => 'tide_landing_page_set_value_hero_image_theme',
     ],
   ];
   $form['field_landing_page_hero_image']['widget']['field_landing_page_hero_theme']['#states']['disabled'] = [

--- a/modules/tide_landing_page/tide_landing_page.module
+++ b/modules/tide_landing_page/tide_landing_page.module
@@ -7,7 +7,7 @@
 
 use Drupal\Core\Ajax\AjaxResponse;
 use Drupal\Core\Ajax\InvokeCommand;
- use Drupal\Core\Cache\Cache;
+use Drupal\Core\Cache\Cache;
 use Drupal\Core\Field\WidgetBase;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Render\Element;

--- a/modules/tide_publication/tide_publication.module
+++ b/modules/tide_publication/tide_publication.module
@@ -132,6 +132,12 @@ function _tide_publication_form_node_form_process(array $form, FormStateInterfac
     ':input[name="_header_style_options"]' => ['value' => 'corner'],
   ];
 
+  $form['field_landing_page_hero_image']['#states']['visible'] = [
+    ':input[name="_header_style_options"]' => [
+      ['value' => 'fullwidth'],
+      ['value' => 'cta'],
+    ],
+  ];
   // Determine the initial value of Header style.
   $node_hero_image_empty = $node->get('field_landing_page_hero_image')->isEmpty();
   $header_style = 'default';

--- a/modules/tide_publication/tide_publication.module
+++ b/modules/tide_publication/tide_publication.module
@@ -128,11 +128,8 @@ function _tide_publication_form_node_form_process(array $form, FormStateInterfac
     ],
   ];
 
-  $form['field_landing_page_hero_image']['#states']['visible'] = [
-    ':input[name="_header_style_options"]' => [
-      ['value' => 'fullwidth'],
-      ['value' => 'cta'],
-    ],
+  $form['field_landing_page_hero_image']['widget']['field_landing_page_hero_theme']['#states']['enabled'] = [
+    ':input[name="_header_style_options"]' => ['value' => 'corner'],
   ];
 
   // Determine the initial value of Header style.


### PR DESCRIPTION
### Jira
https://digital-vic.atlassian.net/browse/SD-22
BE testing link: https://nginx-php.pr-468.content-reference-sdp-vic-gov-au.sdp4.sdp.vic.gov.au/
### Note
This is a new PR based on the initial implementation on this [PR](https://github.com/dpc-sdp/tide_core/pull/516) 
After further testing the AJAX approach suggested, I noticed there was an scenario that didn't work which it is related to this [bug](https://www.drupal.org/project/drupal/issues/1091852). So,  I am reverting back to full JS solution.
### Problem/Motivation
We want to have these scenarios for customised header: 
1. Corner graphics - Light + Dark (Both options available and by default Light should be selected),
2. Full background image - Dark only (Only one option should be set) 
3. CTA - Light only (Only one option should be set).
4. Default appearance - Light only (Only one option should be set)

### Fix
1. Set field `field_landing_page_hero_theme` to mandatory.
2.  Remove a patch for drupal/jsonapi_extras as new released was done and patch is not needed anymore.
3. Fix typo in label : Here image theme.
4. Updated behat test.
5. Updated tide publication module to make it work in publication and publication page content type. 
### Related PRs

### Screenshots
As discussed, the script was working since the code for attaching the library already existed. 

<img width="699" alt="Screenshot 2024-11-26 at 11 20 32 pm" src="https://github.com/user-attachments/assets/6ff2b30a-1541-42d5-a5ce-7033a9c5a1d9">



**Testing for Landing page, publication and publication page:**



<img width="888" alt="Screenshot 2024-11-27 at 12 26 20 am" src="https://github.com/user-attachments/assets/46e5614e-fa86-4605-ac67-eea9b4b2f810">
<img width="953" alt="Screenshot 2024-11-27 at 12 25 46 am" src="https://github.com/user-attachments/assets/78977031-bf92-4ed0-b841-e81bf3b612ca">
<img width="828" alt="Screenshot 2024-11-27 at 12 25 14 am" src="https://github.com/user-attachments/assets/216baef2-5608-4ebc-bfa2-2290ebb78fe4">

### TODO
