### PR TITLE
Task/Fix tfa email template and enable tfa

### DIFF
--- a/modules/tide_tfa/src/TideTfaOperation.php
+++ b/modules/tide_tfa/src/TideTfaOperation.php
@@ -102,16 +102,25 @@ class TideTfaOperation {
       'tfa_email_otp' => [
         'code_validity_period' => '600',
         'email_setting' => [
-          'subject' => '[site:name] Authentication code',
-          'body' => '[user:display-name],\r\n\r\nThis code is valid for [length] minutes. Your code is: [code]\r\n\r\nThis code will expire once you have logged in.',
+          'subject' => 'Single Digtial Presence CMS two-factor authentication code',
+          'body' => '[user:display-name],\r\n\r\nThis code is valid for [length] minutes. \r\n\r\nYour code is: [code]\r\n\r\nThis code will expire once you have logged in.',
         ],
+      ],
+    ];
+    $mail_settings = [
+      'tfa_enabled_configuration' => [
+        'subject' => 'Your Single Digtial Presence CMS account now has two-factor authentication',
+        'body' => "[user:display-name],\r\n\r\nThanks for configuring two-factor authentication on your Single Digital Presence account!\r\n\r\nThis additional level of security will help to ensure that only you are able to log in to your account.\r\n\r\nIf you ever lose the device you configured, you should act quickly to delete its association with this account.\r\n\r\nFrom the SDP team\r\n\r\nRead more about 2FA: https://digital-vic.atlassian.net/servicedesk/customer/article/2439479507",
+      ],
+      'tfa_disabled_configuration' => [
+        'subject' => 'Your Single Digtial Presence CMS account now has two-factor authentication',
+        'body' => "[user:display-name],\r\n\r\nThanks for configuring two-factor authentication on your Single Digital Presence account!\r\n\r\nThis additional level of security will help to ensure that only you are able to log in to your account.\r\n\r\nIf you ever lose the device you configured, you should act quickly to delete its association with this account.\r\n\r\nFrom the SDP team\r\n\r\nRead more about 2FA: https://digital-vic.atlassian.net/servicedesk/customer/article/2439479507",
       ],
     ];
 
     $tfa_settings = \Drupal::configFactory()->getEditable('tfa.settings');
     $tfa_settings->set('enabled', FALSE)
       ->set('required_roles', $tfa_required_roles)
-      ->set('forced', 1)
       ->set('login_plugin_settings', $login_plugin_settings)
       ->set('allowed_validation_plugins', $allowed_validation_plugins)
       ->set('default_validation_plugin', self::DEFAULT_VALIDATION_PLUGIN)
@@ -119,6 +128,7 @@ class TideTfaOperation {
       ->set('encryption', self::ENCRYPTION_PROFILE)
       ->set('users_without_tfa_redirect', TRUE)
       ->set('reset_pass_skip_enabled', TRUE)
+      ->set('mail', $mail_settings)
       ->save();
   }
 

--- a/tests/behat/features/tide_2fa.feature
+++ b/tests/behat/features/tide_2fa.feature
@@ -25,8 +25,6 @@ Feature: Force 2FA setup
     And I see the text "TFA Settings"
     And I see field "edit-tfa-enabled"
     And the "edit-tfa-enabled" checkbox should not be checked
-    And I see field "edit-tfa-forced"
-    And the "edit-tfa-forced" checkbox should be checked
     Then I save screenshot
     Examples:
       | role               |

--- a/tide_core.install
+++ b/tide_core.install
@@ -304,3 +304,15 @@ function tide_core_update_10009() {
     }
   }
 }
+
+/**
+ * Enable tide_tfa.
+ */
+function tide_core_update_10010() {
+  // Enabled tide_tfa module.
+  if (!\Drupal::moduleHandler()->moduleExists('tide_tfa')) {
+    /** @var \Drupal\Core\Extension\ModuleInstallerInterface $module_installer */
+    $module_installer = \Drupal::service('module_installer');
+    $module_installer->install(['tide_tfa']);
+  }
+}


### PR DESCRIPTION
### Jira

### Problem/Motivation

### Fix
1. The email template will be the same for all projects, rather than updating each site separately, adding it in the install hook.
2. Enabling the tide_tfa, it will enable the module but the tfa function will be disabled by default until it is turned on by the tfa settings separately. 
3. Removed the option to check the force tfa be default as the related patch has some issue related to css.
4. Updated the behat to accomodate the change.
5. 
### Related PRs

### Screenshots

### TODO
