### PR TITLE
Fixed link search background issue in ckeditor ribbon

### DIFF
--- a/css/ckeditor_overrides.css
+++ b/css/ckeditor_overrides.css
@@ -14,3 +14,10 @@ button.ck.ck-button[data-cke-tooltip-text="Media"] svg {
 .ck.ck-content.ck-editor__editable {
   min-height: 200px;
 }
+
+.ck-link-form {
+  .ck-reset_all-excluded {
+    background-color: rgba(265, 256, 257, 21.4) !important;
+  }
+}
+


### PR DESCRIPTION
### Jira
https://digital-vic.atlassian.net/browse/SD-393

### Problem/Motivation
Link search popup in ckeditor is having transparent background on searching link.

### Fix
1. Added background color in ckeditor override css.

### Related PRs

### Screenshots

### TODO
