### PR TITLE
added menu local task alter to restrict edit profile for securefile user

### DIFF
--- a/modules/tide_media/tide_media.module
+++ b/modules/tide_media/tide_media.module
@@ -479,7 +479,6 @@ function tide_media_preprocess_page(&$variables) {
     $url = Url::fromRoute('entity.user.canonical', ['user' => $current_user->id()]);
     $response = new RedirectResponse($url->toString());
     $response->send();
-    exit();
   }
 }
 
@@ -489,11 +488,14 @@ function tide_media_preprocess_page(&$variables) {
 function tide_media_menu_local_tasks_alter(&$data, $route_name, RefinableCacheableDependencyInterface &$cacheability) {
   $current_user = \Drupal::currentUser();
   $roles = $current_user->getRoles();
-
-  if (in_array('secure_file_user', $roles)) {
-    foreach ($data['tabs'][0] as $key => $items) {
-      if ($key === 'entity.user.edit_form') {
-        unset($data['tabs'][0][$key]);
+  if (in_array('secure_file_user', $roles, TRUE) && isset($data['tabs'])) {
+    foreach ($data['tabs'] as $key => &$tabs) {
+      if (is_array($tabs)) {
+        foreach ($tabs as $tab_key => $tab) {
+          if ($tab_key === 'entity.user.edit_form') {
+            unset($tabs[$tab_key]);
+          }
+        }
       }
     }
   }

--- a/modules/tide_media/tide_media.module
+++ b/modules/tide_media/tide_media.module
@@ -476,7 +476,7 @@ function tide_media_preprocess_page(&$variables) {
   $roles = $current_user->getRoles();
 
   if ($route_name === 'entity.user.edit_form' && in_array('secure_file_user', $roles)) {
-    $url = \Drupal\Core\Url::fromRoute('entity.user.canonical', ['user' => $current_user->id()]);
+    $url = Url::fromRoute('entity.user.canonical', ['user' => $current_user->id()]);
     $response = new RedirectResponse($url->toString());
     $response->send();
     exit();

--- a/modules/tide_media/tide_media.module
+++ b/modules/tide_media/tide_media.module
@@ -159,7 +159,7 @@ function tide_media_preprocess_field(&$variables) {
   $roles = $current_user->getRoles();
 
   if ($route_name === 'entity.user.edit_form' && in_array('secure_file_user', $roles)) {
-    $url = \Drupal\Core\Url::fromRoute('entity.user.canonical', ['user' => $current_user->id()]);
+    $url = Url::fromRoute('entity.user.canonical', ['user' => $current_user->id()]);
     $response = new RedirectResponse($url->toString());
     $response->send();
     exit();

--- a/modules/tide_media/tide_media.module
+++ b/modules/tide_media/tide_media.module
@@ -154,17 +154,6 @@ function tide_media_form_media_form_alter(&$form, FormStateInterface $form_state
  * Implements template_preprocess_field().
  */
 function tide_media_preprocess_field(&$variables) {
-  $route_name = \Drupal::routeMatch()->getRouteName();
-  $current_user = \Drupal::currentUser();
-  $roles = $current_user->getRoles();
-
-  if ($route_name === 'entity.user.edit_form' && in_array('secure_file_user', $roles)) {
-    $url = Url::fromRoute('entity.user.canonical', ['user' => $current_user->id()]);
-    $response = new RedirectResponse($url->toString());
-    $response->send();
-    exit();
-  }
-
   if ($variables['field_name'] == 'field_media_file') {
     $element = $variables['element'];
     if ($element['#entity_type'] == 'media' && $element['#bundle'] == 'document' && $element['#view_mode'] == 'embedded') {
@@ -475,6 +464,22 @@ function tide_media_file_presave(FileInterface $file) {
     $file_service->move($file->getFileUri(), $path['dirname'] . '/' . $filename_new, FileSystemInterface::EXISTS_REPLACE);
     $file->setFileUri($path['dirname'] . '/' . $filename_new);
     $file->setFilename($filename_new);
+  }
+}
+
+/**
+ * Implements hook_preprocess_HOOK().
+ */
+function tide_media_preprocess_page(&$variables) {
+  $route_name = \Drupal::routeMatch()->getRouteName();
+  $current_user = \Drupal::currentUser();
+  $roles = $current_user->getRoles();
+
+  if ($route_name === 'entity.user.edit_form' && in_array('secure_file_user', $roles)) {
+    $url = \Drupal\Core\Url::fromRoute('entity.user.canonical', ['user' => $current_user->id()]);
+    $response = new RedirectResponse($url->toString());
+    $response->send();
+    exit();
   }
 }
 

--- a/modules/tide_media/tide_media.module
+++ b/modules/tide_media/tide_media.module
@@ -6,6 +6,7 @@
  */
 
 use Drupal\Component\Render\FormattableMarkup;
+use Drupal\Core\Cache\RefinableCacheableDependencyInterface;
 use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Entity\EntityTypeInterface;
 use Drupal\Core\Field\BaseFieldDefinition;
@@ -16,6 +17,7 @@ use Drupal\Core\Link;
 use Drupal\Core\Url;
 use Drupal\file\FileInterface;
 use Drupal\views\ViewExecutable;
+use Symfony\Component\HttpFoundation\RedirectResponse;
 
 /**
  * Implements hook_views_pre_view().
@@ -152,6 +154,17 @@ function tide_media_form_media_form_alter(&$form, FormStateInterface $form_state
  * Implements template_preprocess_field().
  */
 function tide_media_preprocess_field(&$variables) {
+  $route_name = \Drupal::routeMatch()->getRouteName();
+  $current_user = \Drupal::currentUser();
+  $roles = $current_user->getRoles();
+
+  if ($route_name === 'entity.user.edit_form' && in_array('secure_file_user', $roles)) {
+    $url = \Drupal\Core\Url::fromRoute('entity.user.canonical', ['user' => $current_user->id()]);
+    $response = new RedirectResponse($url->toString());
+    $response->send();
+    exit();
+  }
+
   if ($variables['field_name'] == 'field_media_file') {
     $element = $variables['element'];
     if ($element['#entity_type'] == 'media' && $element['#bundle'] == 'document' && $element['#view_mode'] == 'embedded') {
@@ -462,5 +475,21 @@ function tide_media_file_presave(FileInterface $file) {
     $file_service->move($file->getFileUri(), $path['dirname'] . '/' . $filename_new, FileSystemInterface::EXISTS_REPLACE);
     $file->setFileUri($path['dirname'] . '/' . $filename_new);
     $file->setFilename($filename_new);
+  }
+}
+
+/**
+ * Implements hook_menu_local_tasks_alter().
+ */
+function tide_media_menu_local_tasks_alter(&$data, $route_name, RefinableCacheableDependencyInterface &$cacheability) {
+  $current_user = \Drupal::currentUser();
+  $roles = $current_user->getRoles();
+
+  if (in_array('secure_file_user', $roles)) {
+    foreach ($data['tabs'][0] as $key => $items) {
+      if ($key === 'entity.user.edit_form') {
+        unset($data['tabs'][0][$key]);
+      }
+    }
   }
 }


### PR DESCRIPTION
### Jira
https://digital-vic.atlassian.net/browse/SD-460
Testing link in content-vic: https://nginx-php.pr-1755.content-vic.sdp4.sdp.vic.gov.au/
### Problem/Motivation

### Fix
Hide edit tab user by adding a menu local task alter function in vicgovau_core.module and unset the tab for a Secure File User role.
2.Redirect the link content.vic/user/user_id/edit to content.vic/user/user_id/ in a preprocess_page function.
### Related PRs

### Screenshots
![Screenshot 2024-12-11 at 1 56 13 pm](https://github.com/user-attachments/assets/cf3953e8-64c2-443a-bae3-78eec5649212)

### TODO
Note: I discovered that the "Secure File" user role is missing the necessary permissions. For testing purposes, I manually enabled the toolbar to allow the user to log out. I will be creating a new ticket with all relevant details for further investigation and resolution.