### PR TITLE
[SD-623]remove required height and width for embedded content

### DIFF
--- a/modules/tide_ckeditor/src/Plugin/EmbeddedContent/TideIframe.php
+++ b/modules/tide_ckeditor/src/Plugin/EmbeddedContent/TideIframe.php
@@ -66,13 +66,11 @@ class TideIframe extends EmbeddedContentPluginBase implements EmbeddedContentInt
       '#type' => 'textfield',
       '#title' => $this->t('Width'),
       '#default_value' => $this->configuration['width'],
-      '#required' => TRUE,
     ];
     $form['height'] = [
       '#type' => 'textfield',
       '#title' => $this->t('Height'),
       '#default_value' => $this->configuration['height'],
-      '#required' => TRUE,
     ];
     return $form;
   }


### PR DESCRIPTION
### Jira
https://digital-vic.atlassian.net/browse/SD-623
### Problem/Motivation
The height and width fields are mandatory in the iframe embed modal and it needs to be changed to non mandatory.
### Fix
Removed '#required' => TRUE, for both width and height
### Related PRs

### Screenshots

### TODO
