### PR TITLE
[SD-578] add review component field

### DIFF
--- a/modules/tide_webform/src/Plugin/WebformElement/WebformReviewComponent.php
+++ b/modules/tide_webform/src/Plugin/WebformElement/WebformReviewComponent.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Drupal\tide_webform\Plugin\WebformElement;
+
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\webform\Plugin\WebformElement\Item;
+
+/**
+ * Provides a 'review_component' element.
+ *
+ * Note: This is essentially a placeholder field for the frontend.
+ *
+ * @WebformElement(
+ *   id = "webform_review_component",
+ *   default_key = "review_component",
+ *   label = @Translation("Review component"),
+ *   description = @Translation("Displays a review component."),
+ *   category = @Translation("Composite elements"),
+ * )
+ */
+class WebformReviewComponent extends Item {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getDefaultProperties(): array {
+    return [
+      'title' => $this->t('Review component'),
+    ];
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function form(array $form, FormStateInterface $form_state): array {
+    $form = parent::form($form, $form_state);
+
+    // Remove unneeded form settings.
+    unset($form['form']);
+    unset($form['markup']);
+    unset($form['validation']);
+    unset($form['element_description']);
+
+    return $form;
+  }
+
+}


### PR DESCRIPTION
### Jira

https://digital-vic.atlassian.net/browse/SD-578
Testing link: https://nginx-php.pr-1805.content-vic.sdp4.sdp.vic.gov.au/
### Problem/Motivation

The frontend needed a new placeholder field to allow for a review component to be inserted in the correct location.

### Fix

Adds a new webform field that acts placeholder, meaning it doesn't need all the extra field options that other fields have.

### Screenshots

<img width="761" alt="Screenshot 2025-02-10 at 5 01 34 pm" src="https://github.com/user-attachments/assets/d2152815-6eb0-47d9-b81a-27b4451bfca0" />

<img width="406" alt="Screenshot 2025-02-10 at 5 03 01 pm" src="https://github.com/user-attachments/assets/584768c9-dcc1-4e20-a3c6-89fb5a772e86" />

Hey @anthony-malkoun @yeniatencio, does this need a test? I could look at adding a test for a multistep/wizard form that includes this. Also, I don't have any contextual knowledge here so please let me know if I've missed anything and or done anything incorrectly. Thanks

