### PR TITLE
Update audit node command for D10

### DIFF
--- a/modules/tide_api/src/Plugin/jsonapi/FieldEnhancer/YamlEnhancer.php
+++ b/modules/tide_api/src/Plugin/jsonapi/FieldEnhancer/YamlEnhancer.php
@@ -24,9 +24,10 @@ class YamlEnhancer extends ResourceFieldEnhancerBase {
   protected function doUndoTransform($data, Context $context) {
     $data = Yaml::decode($data);
 
-    if (!empty($data['markup']['#markup'])) {
-      $data['processed_text']['#text'] = $this->processText($data['markup']['#markup']);
+    if (!empty($data['processed_text']['#text'])) {
+      $data['processed_text']['#text'] = $this->processText($data['processed_text']['#text']);
     }
+
     if (!empty($data['markup']['#markup'])) {
       $data['markup']['#markup'] = $this->processText($data['markup']['#markup']);
     }

--- a/modules/tide_search/src/Commands/TideSearchCommands.php
+++ b/modules/tide_search/src/Commands/TideSearchCommands.php
@@ -19,11 +19,22 @@ use Drush\Commands\DrushCommands;
 class TideSearchCommands extends DrushCommands {
 
   /**
-   * Audit nodeids that needs to be published/indexed based on search index.
+   * Audits node ids that needs to be published/indexed based on search index.
+   * 
+   * The list of items not in the search index can be added using the following
+   * command where '--id-list' is the output from running 'tide:search-audit-nodes'
+   * 
+   * 'drush search-api:index-sample --datasource=entity:node --id-list=1234,4567'
+   * 
+   * @param string $indexId The name of the Search API index to audit, e.g. 'node'
+   * 
+   * @return string
+   *   A comma delimited list of ids that can be passed to
+   *   'drush search_api:index-sample'
    *
-   * @usage drush tide-search-audit-nodes
-   *   Update the domains on the site taxonomy based on an environment variable.
-   *
+   * @usage drush tide-search-audit-nodes node
+   *   Audit 'node' index for missing items
+   * 
    * @command tide:search-audit-nodes
    * @aliases tide-san,tide-search-audit-nodes
    *
@@ -146,6 +157,7 @@ class TideSearchCommands extends DrushCommands {
         ->condition('type', 'alert', '!=')
         ->condition('status', 1)
         ->sort('nid')
+        ->accessCheck(FALSE)
         ->condition('nid', $pointer, '>')
         ->range(0, 100)
         ->execute();

--- a/modules/tide_search/src/Commands/TideSearchCommands.php
+++ b/modules/tide_search/src/Commands/TideSearchCommands.php
@@ -20,21 +20,23 @@ class TideSearchCommands extends DrushCommands {
 
   /**
    * Audits node ids that needs to be published/indexed based on search index.
-   * 
+   *
    * The list of items not in the search index can be added using the following
-   * command where '--id-list' is the output from running 'tide:search-audit-nodes'
-   * 
-   * 'drush search-api:index-sample --datasource=entity:node --id-list=1234,4567'
-   * 
-   * @param string $indexId The name of the Search API index to audit, e.g. 'node'
-   * 
+   * command where '--id-list' is the output from running
+   * 'tide:search-audit-nodes'
+   *
+   * 'drush search-api:index-sample --datasource=entity:node --id-list=123,456'
+   *
+   * @param string $indexId
+   *   The name of the Search API index to audit, e.g. 'node'.
+   *
    * @return string
    *   A comma delimited list of ids that can be passed to
    *   'drush search_api:index-sample'
    *
    * @usage drush tide-search-audit-nodes node
    *   Audit 'node' index for missing items
-   * 
+   *
    * @command tide:search-audit-nodes
    * @aliases tide-san,tide-search-audit-nodes
    *

--- a/modules/tide_search/src/Commands/TideSearchCommands.php
+++ b/modules/tide_search/src/Commands/TideSearchCommands.php
@@ -102,14 +102,14 @@ class TideSearchCommands extends DrushCommands {
       throw new ConsoleException(t('@index was not found'));
     }
     $total = $indexes[$indexId]->getTrackerInstance()->getTotalItemsCount();
-    $no_of_batches = ceil($total / 1000);
-    // If the result set is more than 1000 then run it in batch.
+    $no_of_batches = ceil($total / 500);
+    // If the result set is more than 500 then run it in batch.
     if ($no_of_batches > 1) {
       $nid_starting_point = 0;
       for ($i = 1; $i <= $no_of_batches; $i++) {
         try {
           $query = $indexes[$indexId]->query();
-          $query->range(0, 1000);
+          $query->range(0, 500);
           $query->sort('nid');
           $query->addCondition('nid', $nid_starting_point, '>');
           $results = $query->execute();


### PR DESCRIPTION
### Jira

https://digital-vic.atlassian.net/browse/SDPSUP-8990

### Problem/Motivation

D10 requires that all entity queries have an explicit access check. See https://www.drupal.org/node/3201242 for reference.

> For Drupal 10 this will be enforced by throwing an exception if ::accessCheck() is not called.

While there, the help text has been corrected and had some examples added because I forget how to use it every time :)

### Fix

Add the access check.

### Related PRs

### Screenshots

### TODO
