### PR TITLE
[SD-675]added edit any media permission to approver

### DIFF
--- a/config/install/user.role.approver.yml
+++ b/config/install/user.role.approver.yml
@@ -44,6 +44,7 @@ permissions:
   - 'create paragraph library item'
   - 'edit paragraph library item'
   - 'delete all revisions'
+  - 'delete any media'
   - 'delete media'
   - 'edit any audio media'
   - 'edit any document media'

--- a/modules/tide_media/tide_media.install
+++ b/modules/tide_media/tide_media.install
@@ -137,3 +137,11 @@ function tide_media_update_10007() {
   $config->set('hidden', $hidden);
   $config->save();
 }
+
+/**
+ * Add edit any media permission to approver.
+ */
+function tide_media_update_10008() {
+  $permission = ['delete any media'];
+  user_role_grant_permissions('approver', $permission);
+}


### PR DESCRIPTION
### Jira
https://digital-vic.atlassian.net/browse/SD-675
Testing link: https://nginx-php.pr-511.content-reference-sdp-vic-gov-au.sdp4.sdp.vic.gov.au/
### Problem/Motivation
 Approver role should be able to delete any media
### Fix
Add a update hook to assign the permission to approver in tide_media module
### Related PRs

### Screenshots
![Screenshot 2025-03-18 at 9 40 18 am](https://github.com/user-attachments/assets/ff9a95c2-68b0-4c27-982f-6a598b8a5474)
![Screenshot 2025-03-18 at 9 39 44 am](https://github.com/user-attachments/assets/ceec64ce-f73e-45cc-938d-5526eb5c7eb5)
![Screenshot 2025-03-18 at 9 39 10 am](https://github.com/user-attachments/assets/5b0bc887-f85b-4e13-a192-8c57e8e3b423)

### TODO
