### PR TITLE
[SD-642] Improve cleaning of expired submissions

### DIFF
--- a/modules/tide_webform/src/Commands/TideWebformSubmissionsCleanUp.php
+++ b/modules/tide_webform/src/Commands/TideWebformSubmissionsCleanUp.php
@@ -7,6 +7,7 @@ use Drupal\webform\Entity\Webform;
 use Drupal\webform\Entity\WebformSubmission;
 use Drush\Commands\DrushCommands;
 use Drush\Drush;
+use Respect\Validation\Validator as v;
 
 /**
  * Drush command.
@@ -18,39 +19,116 @@ class TideWebformSubmissionsCleanUp extends DrushCommands {
    *
    * @param string $webform_id
    *   The webform ID.
-   * @param string $date_string
-   *   The date string.
-   * @param string $webform_field
-   *   The webform field to check.
+   * @param string|int $date_param
+   *   The date string or number of days.
+   * @param string $end_date
+   *   Optional end date for date range.
    *
    * @command tide_webform:cleanup_submissions
-   * @aliases twc
-   * @usage tide_webform:cleanup_submissions tide_webform_content_rating 07-May-2024 was_this_page_helpful
+   * @aliases tsc
+   * @usage tide_webform:cleanup_submissions tide_webform_content_rating 07-May-2024
    *   Clean up submissions for 'tide_webform_content_rating' on '07-May-2024'
-   * where 'was_this_page_helpful' field is empty or does not exist.
+   * @usage tide_webform:cleanup_submissions tide_webform_content_rating 07-May-2024 01-May-2024
+   *   Clean up submissions between '01-May-2024' and '07-May-2024'
+   * @usage tide_webform:cleanup_submissions tide_webform_content_rating 30
+   *   Clean up submissions older than 30 days
    */
-  public function cleanupSubmissions($webform_id, $date_string, $webform_field) {
+  public function cleanupSubmissions($webform_id, $date_param = NULL, $end_date = NULL) {
     $webform = Webform::load($webform_id);
     if (!$webform) {
       Drush::output()->writeln("Webform with ID $webform_id does not exist.");
       return;
     }
 
-    if (!$webform->getElement($webform_field) || !$webform->getElement($webform_field)['#required']) {
-      Drush::output()->writeln("The field $webform_field is not a required field.");
+    // Check if date parameter is provided.
+    if (is_null($date_param)) {
+      Drush::output()->writeln("Missing date parameter. Please provide a date, date range, or number of days.");
       return;
     }
 
-    $date_start = new DrupalDateTime($date_string);
-    $date_start->setTime(0, 0, 0);
-    $date_end = new DrupalDateTime($date_string);
-    $date_end->setTime(23, 59, 59);
+    // Case 1: A numeric value representing days ago.
+    if (is_numeric($date_param)) {
+      $days = (int) $date_param;
+      $cutoff_date = new DrupalDateTime();
+      $cutoff_date->modify("-$days days");
+      $cutoff_date->setTime(0, 0, 0);
 
-    $query = \Drupal::entityQuery('webform_submission')
-      ->condition('webform_id', $webform_id)
-      ->condition('created', $date_start->getTimestamp(), '>=')
-      ->condition('created', $date_end->getTimestamp(), '<=')
-      ->accessCheck(FALSE);
+      $query = \Drupal::entityQuery('webform_submission')
+        ->condition('webform_id', $webform_id)
+        ->condition('created', $cutoff_date->getTimestamp(), '<')
+        ->accessCheck(FALSE)
+        ->range(0, 100);
+    }
+    // Case 2: Two dates provided for a range.
+    elseif (!is_null($end_date)) {
+      // Validate date formats - use 'd-M-Y' format for DD-MMM-YYYY (e.g.,
+      // 07-May-2024)
+      if (!$this->isValidDate($date_param) || !$this->isValidDate($end_date)) {
+        Drush::output()->writeln("Invalid date format. Please provide dates in the format 'DD-MMM-YYYY' (e.g., '07-May-2024').");
+        return;
+      }
+
+      try {
+        $date1 = new DrupalDateTime($date_param);
+        $date2 = new DrupalDateTime($end_date);
+
+        // Determine which date is earlier.
+        if ($date1 < $date2) {
+          $date_start = $date1;
+          $date_end = $date2;
+        }
+        else {
+          $date_start = $date2;
+          $date_end = $date1;
+        }
+
+        $date_start->setTime(0, 0, 0);
+        $date_end->setTime(23, 59, 59);
+
+        $query = \Drupal::entityQuery('webform_submission')
+          ->condition('webform_id', $webform_id)
+          ->condition('created', $date_start->getTimestamp(), '>=')
+          ->condition('created', $date_end->getTimestamp(), '<=')
+          ->accessCheck(FALSE)
+          ->range(0, 100);
+      }
+      catch (\Exception $e) {
+        Drush::output()->writeln("Error processing dates: " . $e->getMessage());
+        return;
+      }
+    }
+    // Case 3: Single date provided.
+    else {
+      // Validate date format - use 'd-M-Y' format for DD-MMM-YYYY
+      // (e.g., 07-May-2024)
+      if (!$this->isValidDate($date_param)) {
+        Drush::output()->writeln("Invalid date format. Please provide a date in the format 'DD-MMM-YYYY' (e.g., '07-May-2024').");
+        return;
+      }
+
+      try {
+        $date = new DrupalDateTime($date_param);
+        $date_start = clone $date;
+        $date_start->setTime(0, 0, 0);
+        $date_end = clone $date;
+        $date_end->setTime(23, 59, 59);
+        error_log($date_start->getTimestamp());
+        error_log($date_end->getTimestamp());
+
+        $query = \Drupal::entityQuery('webform_submission')
+          ->condition('webform_id', $webform_id)
+          ->condition('created', $date_start->getTimestamp(), '>=')
+          ->condition('created', $date_end->getTimestamp(), '<=')
+          ->accessCheck(FALSE)
+          ->range(0, 100);
+      }
+      catch (\Exception $e) {
+        Drush::output()->writeln("Error processing date: " . $e->getMessage());
+        return;
+      }
+    }
+
+    // Execute the query and process results.
     $sids = $query->execute();
 
     if (empty($sids)) {
@@ -67,7 +145,7 @@ class TideWebformSubmissionsCleanUp extends DrushCommands {
     foreach ($sids as $sid) {
       $batch['operations'][] = [
         [get_class($this), 'deleteSubmission'],
-        [$sid, $webform_field],
+        [$sid],
       ];
     }
 
@@ -76,11 +154,34 @@ class TideWebformSubmissionsCleanUp extends DrushCommands {
   }
 
   /**
+   * Validates a date string in multiple acceptable formats.
+   *
+   * @param string $date
+   *   The date string to validate.
+   *
+   * @return bool
+   *   TRUE if the date is valid, FALSE otherwise.
+   */
+  private function isValidDate($date) {
+    // Try with common formats that might be used.
+    // 07-May-2024.
+    return v::date('d-M-Y')->validate($date) ||
+    // 7-May-2024
+           v::date('j-M-Y')->validate($date) ||
+    // 07-May-2024 (full month name)
+           v::date('d-F-Y')->validate($date) ||
+    // 7-May-2024 (full month name)
+           v::date('j-F-Y')->validate($date) ||
+    // 2024-05-07 (ISO format)
+           v::date('Y-m-d')->validate($date);
+  }
+
+  /**
    * Batch operation callback for deleting a submission.
    */
-  public static function deleteSubmission($sid, $webform_field, &$context) {
+  public static function deleteSubmission($sid, &$context) {
     $submission = WebformSubmission::load($sid);
-    if ($submission && ($submission->getElementData($webform_field) === '' || is_null($submission->getElementData($webform_field)))) {
+    if ($submission) {
       $submission->delete();
       $context['results']['deleted'][] = $sid;
     }


### PR DESCRIPTION
### Jira
https://digital-vic.atlassian.net/browse/SD-642

### Usage

#### Overview
```
drush tide_webform:cleanup_submissions [webform_id] [date_parameter] [end_date]
# or use the alias
drush tsc [webform_id] [date_parameter] [end_date]
```

1. Delete submissions from a specific date
`drush tsc tide_webform_content_rating 07-May-2024`

2. Delete submissions within a date range
`drush tsc tide_webform_content_rating 07-May-2024 01-May-2024`

3. Delete submissions older than X days
`drush tsc tide_webform_content_rating 30`
This will delete all submissions older than 30 days.

#### Supported Date Formats
```
DD-MMM-YYYY (e.g., 07-May-2024)
D-MMM-YYYY (e.g., 7-May-2024)
DD-MONTH-YYYY (e.g., 07-May-2024)
D-MONTH-YYYY (e.g., 7-May-2024)
YYYY-MM-DD (e.g., 2024-05-07)
```

#### Notes
1. The command processes submissions in batches of 100
2. This command will be applied to [this file](https://github.com/dpc-sdp/content-vic-gov-au/blob/develop/.lagoon.yml#L146) to delete the following submissions:
```
   tide_webform_content_rating
   connect_with_us
   hayley_test_vsba
```

related to 
    -  https://github.com/dpc-sdp/content-vic-gov-au/pull/1818