### PR TITLE
[SD-751] allow addition of top and bottom corner graphics for a site …

### DIFF
--- a/src/Plugin/CornerGraphicField.php
+++ b/src/Plugin/CornerGraphicField.php
@@ -1,0 +1,158 @@
+<?php
+
+namespace Drupal\tide_core\Plugin;
+
+use Drupal\Core\Cache\CacheableMetadata;
+use Drupal\Core\Field\FieldItemList;
+use Drupal\Core\TypedData\ComputedItemListTrait;
+use Drupal\node\NodeInterface;
+use Drupal\taxonomy\Entity\Term;
+
+/**
+ * Corner Graphic field implementation.
+ */
+class CornerGraphicField extends FieldItemList {
+
+  use ComputedItemListTrait;
+
+  /**
+   * Computes the field value.
+   */
+  protected function computeValue() {
+    $node = $this->getEntity();
+    if (!$node instanceof NodeInterface) {
+      return;
+    }
+    if (!\Drupal::moduleHandler()->moduleExists('tide_site')) {
+      return;
+    }
+    $site_id = \Drupal::request()->get('site');
+    /** @var \Drupal\tide_site\TideSiteHelper $siteHelper */
+    $siteHelper = \Drupal::service('tide_site.helper');
+    // Return can be null or term entity.
+    $primary_site_term_entity = $siteHelper->getEntityPrimarySite($node);
+    $file_url_generator = \Drupal::service('file_url_generator');
+
+    $sites = $siteHelper->getEntitySites($node);
+    $valid = $siteHelper->isEntityBelongToSite($node, $site_id);
+
+    if (!$valid || empty($sites['sections'][$site_id])) {
+      return;
+    }
+
+    $section_id = $sites['sections'][$site_id];
+    $details = [];
+    // Try to get corner graphics from the node.
+    if ($this->hasCornerGraphicsInNode($node)) {
+      $this->addNodeCornerGraphics($node, $details, $file_url_generator);
+    }
+    // Fall back to section term corner graphics.
+    else {
+      $term = Term::load($section_id);
+      if ($term && $this->hasCornerGraphicsInTerm($term)) {
+        $this->addTermCornerGraphics($term, $details, $file_url_generator);
+      }
+      // Level 3: Fall back to primary site corner graphics.
+      elseif ($primary_site_term_entity && $this->hasCornerGraphicsInTerm($primary_site_term_entity)) {
+        $this->addTermCornerGraphics($primary_site_term_entity, $details, $file_url_generator);
+      }
+    }
+    $item = $this->createItem(0, $details);
+    $cacheability = (new CacheableMetadata())
+      ->setCacheTags([
+        'taxonomy_term:' . $section_id,
+        'taxonomy_term:' . $primary_site_term_entity->id(),
+        'node:' . $node->id(),
+      ]);
+    $item->get('top_corner_graphic')->addCacheableDependency($cacheability);
+    $item->get('bottom_corner_graphic')->addCacheableDependency($cacheability);
+    $this->list[0] = $item;
+  }
+
+  /**
+   * Checks if the node has any corner graphic fields with values.
+   *
+   * @param \Drupal\node\NodeInterface $node
+   *   The node entity.
+   *
+   * @return bool
+   *   TRUE if the node has corner graphics, FALSE otherwise.
+   */
+  protected function hasCornerGraphicsInNode(NodeInterface $node) {
+    return ($node->hasField('field_graphical_image') && !$node->field_graphical_image->isEmpty()) ||
+      ($node->hasField('field_bottom_graphical_image') && !$node->field_bottom_graphical_image->isEmpty());
+  }
+
+  /**
+   * Adds node corner graphics to the details array.
+   *
+   * @param \Drupal\node\NodeInterface $node
+   *   The node entity.
+   * @param array $details
+   *   The details array to be modified.
+   * @param object $file_url_generator
+   *   The file URL generator service.
+   */
+  protected function addNodeCornerGraphics(NodeInterface $node, array &$details, $file_url_generator) {
+    if ($node->hasField('field_graphical_image') &&
+      !$node->field_graphical_image->isEmpty() &&
+      $node->field_graphical_image->entity &&
+      !$node->field_graphical_image->entity->field_media_image->isEmpty()) {
+
+      $top_corner_graphic_file = $node->field_graphical_image->entity->field_media_image->entity;
+      $details['top_corner_graphic'] = $file_url_generator->generateString($top_corner_graphic_file->getFileUri());
+    }
+
+    if ($node->hasField('field_bottom_graphical_image') &&
+      !$node->field_bottom_graphical_image->isEmpty() &&
+      $node->field_bottom_graphical_image->entity &&
+      !$node->field_bottom_graphical_image->entity->field_media_image->isEmpty()) {
+
+      $bottom_corner_graphic_file = $node->field_bottom_graphical_image->entity->field_media_image->entity;
+      $details['bottom_corner_graphic'] = $file_url_generator->generateString($bottom_corner_graphic_file->getFileUri());
+    }
+  }
+
+  /**
+   * Checks if the term has any corner graphic fields with values.
+   *
+   * @param \Drupal\taxonomy\Entity\Term $term
+   *   The taxonomy term entity.
+   *
+   * @return bool
+   *   TRUE if the term has corner graphics, FALSE otherwise.
+   */
+  protected function hasCornerGraphicsInTerm($term) {
+    return ($term->hasField('field_top_corner_graphic') && !$term->field_top_corner_graphic->isEmpty()) ||
+      ($term->hasField('field_bottom_corner_graphic') && !$term->field_bottom_corner_graphic->isEmpty());
+  }
+
+  /**
+   * Adds term corner graphics to the details array.
+   *
+   * @param \Drupal\taxonomy\Entity\Term $term
+   *   The taxonomy term entity.
+   * @param array $details
+   *   The details array to be modified.
+   * @param object $file_url_generator
+   *   The file URL generator service.
+   */
+  protected function addTermCornerGraphics($term, array &$details, $file_url_generator) {
+    if ($term->hasField('field_top_corner_graphic') &&
+      !$term->field_top_corner_graphic->isEmpty() &&
+      $term->field_top_corner_graphic->entity) {
+
+      $top_corner_graphic_file = $term->field_top_corner_graphic->entity;
+      $details['top_corner_graphic'] = $file_url_generator->generateString($top_corner_graphic_file->getFileUri());
+    }
+
+    if ($term->hasField('field_bottom_corner_graphic') &&
+      !$term->field_bottom_corner_graphic->isEmpty() &&
+      $term->field_bottom_corner_graphic->entity) {
+
+      $bottom_corner_graphic_file = $term->field_bottom_corner_graphic->entity;
+      $details['bottom_corner_graphic'] = $file_url_generator->generateString($bottom_corner_graphic_file->getFileUri());
+    }
+  }
+
+}

--- a/src/Plugin/DataType/ComputedCacheableString.php
+++ b/src/Plugin/DataType/ComputedCacheableString.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Drupal\tide_core\Plugin\DataType;
+
+use Drupal\Core\Cache\RefinableCacheableDependencyInterface;
+use Drupal\Core\Cache\RefinableCacheableDependencyTrait;
+use Drupal\Core\StringTranslation\TranslatableMarkup;
+use Drupal\Core\TypedData\Attribute\DataType;
+use Drupal\Core\TypedData\Plugin\DataType\StringData;
+
+/**
+ * The string data type with cacheability metadata.
+ */
+#[DataType(
+  id: "computed_cacheable_string",
+  label: new TranslatableMarkup("Computed Cacheable String"),
+)]
+class ComputedCacheableString extends StringData implements RefinableCacheableDependencyInterface {
+
+  use RefinableCacheableDependencyTrait;
+
+}

--- a/src/Plugin/Field/FieldType/ComputedCornerGraphicFieldType.php
+++ b/src/Plugin/Field/FieldType/ComputedCornerGraphicFieldType.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Drupal\tide_core\Plugin\Field\FieldType;
+
+use Drupal\Core\Field\FieldItemBase;
+use Drupal\Core\Field\FieldStorageDefinitionInterface;
+use Drupal\Core\TypedData\DataDefinition;
+
+/**
+ * Plugin implementation of the 'corner_graphic_computed' field type.
+ *
+ * @FieldType(
+ *   id = "corner_graphic_computed",
+ *   label = @Translation("corner_graphic_computed"),
+ *   description = @Translation("corner_graphic_computed"),
+ *   no_ui = TRUE,
+ *   list_class = "\Drupal\Core\Field\FieldItemList",
+ * )
+ */
+class ComputedCornerGraphicFieldType extends FieldItemBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function schema(FieldStorageDefinitionInterface $field_definition) {
+    return [];
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function propertyDefinitions(FieldStorageDefinitionInterface $field_definition) {
+    $properties = [];
+    $properties['top_corner_graphic'] = DataDefinition::create('computed_cacheable_string')
+      ->setLabel(t('Top Corner Graphic'))
+      ->setRequired(FALSE);
+    $properties['bottom_corner_graphic'] = DataDefinition::create('computed_cacheable_string')
+      ->setLabel(t('Bottom Corner Graphic'))
+      ->setRequired(FALSE);
+    return $properties;
+  }
+
+}

--- a/tide_core.module
+++ b/tide_core.module
@@ -10,6 +10,8 @@ use Drupal\Core\Access\AccessResult;
 use Drupal\Core\Breadcrumb\Breadcrumb;
 use Drupal\Core\Cache\Cache;
 use Drupal\Core\Entity\EntityInterface;
+use Drupal\Core\Entity\EntityTypeInterface;
+use Drupal\Core\Field\BaseFieldDefinition;
 use Drupal\Core\Field\FieldItemListInterface;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Link;
@@ -23,6 +25,7 @@ use Drupal\node\NodeInterface;
 use Drupal\paragraphs\Entity\Paragraph;
 use Drupal\redirect\Entity\Redirect;
 use Drupal\scheduled_transitions\Routing\ScheduledTransitionsRouteProvider;
+use Drupal\tide_core\Plugin\CornerGraphicField;
 use Drupal\tide_core\Render\Element\AdminToolbar;
 use Drupal\user\RoleInterface;
 use Drupal\views\ViewExecutable;
@@ -863,5 +866,21 @@ function tide_core_process_media_entity_status(array $media_uuids) {
         }
       }
     }
+  }
+}
+
+/**
+ * Implements hook_entity_base_field_info_alter().
+ */
+function tide_core_entity_base_field_info_alter(&$fields, EntityTypeInterface $entity_type) {
+  if ($entity_type->id() == 'node') {
+    $fields['corner_graphic_field'] = BaseFieldDefinition::create('corner_graphic_computed')
+      ->setLabel(t('Corner graphic'))
+      ->setName('corner_graphic_field')
+      ->setDescription(t('Corner graphic custom field'))
+      ->setComputed(TRUE)
+      ->setClass(CornerGraphicField::class)
+      ->setReadOnly(TRUE)
+      ->setCardinality(1);
   }
 }


### PR DESCRIPTION
### Jira
https://digital-vic.atlassian.net/browse/SD-751

### Problem/Motivation
When top and bottom corner graphic files are added in the taxonomy of a site section, the images will flow through to all pages in that site section. If individual images are added at a node level, these will over-ride the site section images.

Add a custom field corner_graphic_field to the node that returns JSON in the following format:

e.g.
```json
    "corner_graphic_field": {
                "top_corner_graphic": "/sites/default/files/2025-04/8788145_0.jpeg",
                "bottom_corner_graphic": "/sites/default/files/2025-04/8788145.jpeg"
            },
```
 
 ```json
             "corner_graphic_field": {
                "top_corner_graphic": null,
                "bottom_corner_graphic": "/sites/default/files/2025-04/8788145.jpeg"
            },
```

```json
                "corner_graphic_field": {
                "top_corner_graphic": null,
                "bottom_corner_graphic": null
            },
```
