### PR TITLE
[SDPSUP-9636] Unset field_published_date value on cloned nodes

### DIFF
--- a/tide_core.module
+++ b/tide_core.module
@@ -884,3 +884,12 @@ function tide_core_entity_base_field_info_alter(&$fields, EntityTypeInterface $e
       ->setCardinality(1);
   }
 }
+
+/**
+ * Implements hook_cloned_node_alter().
+ */
+function tide_core_cloned_node_alter(NodeInterface &$node, NodeInterface $original): void {
+  // Unsets the value of field_published_date on a cloned entity.
+  $node->set('field_published_date', NULL);
+  $node->save();
+}


### PR DESCRIPTION
### Jira

https://digital-vic.atlassian.net/browse/SDPSUP-9636

### Problem/Motivation

Cloned nodes copy the value of `field_published_date` from the source entity. This field is not editable, which means the cloned node is stuck with whatever value was copied across.

This was a particular issue for Digital Public Notices who use that field for display on the front end.

### Fix

This fix unsets the value of `field_published_date` on the cloned entity.

