### PR TITLE
[SD-903] Pin TFA to 1.9 for compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -59,7 +59,7 @@
         "drupal/smtp": "^1.2",
         "drupal/stage_file_proxy": "^2.0",
         "drupal/tablefield": "2.4",
-        "drupal/tfa": "^1.2",
+        "drupal/tfa": "1.9",
         "drupal/tfa_email_otp": "^1.0@beta",
         "drupal/token_conditions": "dev-compatible-with-d10",
         "drupal/token_filter": "^2.0",


### PR DESCRIPTION
### Jira
https://digital-vic.atlassian.net/browse/SD-903
### Problem/Motivation
- https://www.drupal.org/sa-contrib-2025-023
- https://git.drupalcode.org/project/tfa/-/compare/8.x-1.9...8.x-1.10?from_project_id=57554
![CleanShot 2025-05-06 at 14 09 46](https://github.com/user-attachments/assets/b843e851-cd45-4fef-82c5-4079420995e8)

### Fix
To address compatibility issues introduced by drupal/tfa 1.10, this change pins the drupal/tfa dependency to version 1.9 in our composer.json. 
Upgrades to 1.10 will be rolled out as part of a future tide release.

