### PR TITLE
Removed broken tide_event webform email handler

### DIFF
--- a/modules/tide_event/config/install/webform.webform.tide_event_submission.yml
+++ b/modules/tide_event/config/install/webform.webform.tide_event_submission.yml
@@ -276,38 +276,4 @@ access:
       - authenticated
     users: {  }
     permissions: {  }
-handlers:
-  event_submission_email:
-    id: email
-    label: 'Event Submission Email'
-    handler_id: event_submission_email
-    status: true
-    conditions: {  }
-    weight: 0
-    settings:
-      states:
-        - completed
-      to_mail: contact.dpc@dsdbi.desk-mail.com
-      to_options: {  }
-      cc_mail: ''
-      cc_options: {  }
-      bcc_mail: ''
-      bcc_options: {  }
-      from_mail: contact.dpc@dsdbi.desk-mail.com
-      from_options: {  }
-      from_name: _default
-      subject: 'Event Submission'
-      body: _default
-      excluded_elements:
-        agree_privacy_statement: agree_privacy_statement
-      ignore_access: false
-      exclude_empty: true
-      exclude_empty_checkbox: true
-      html: true
-      attachments: false
-      twig: false
-      debug: false
-      reply_to: ''
-      return_path: ''
-      sender_mail: ''
-      sender_name: ''
+handlers: { }


### PR DESCRIPTION
### Jira

N/A

### Problem/Motivation

Currently most (if not all) tide projects are reporting issues with the tide_event webform not sending emails properly.

This is because the webform is configured out-of-the-box with a FROM address for some type of CRM solution that must have been [from the original implementation](https://github.com/dpc-sdp/tide_event/commit/5e5dbe47e129a907a30f056f050d59cbcd1aa067#diff-aa12a57db3b695989dde94fcf01846b45820a3cc134f37f59e00dc65a97b5ae8R275).

### Fix

There is no way to know specifically where each SDP tenant would want this to go, so the fix is just to remove the webform email handler all together.
