### PR TITLE
Add environment indicator setting to display tag deployed

### DIFF
--- a/tide_core.install
+++ b/tide_core.install
@@ -421,3 +421,23 @@ function tide_core_update_10015() {
   // Save the configuration.
   $config->save();
 }
+
+/**
+ * Add code deployed tag to environment.
+ */
+function tide_core_update_10016() {
+  $env = getenv('LAGOON_ENVIRONMENT_TYPE') ?: 'development';
+  $moduleHandler = \Drupal::service('module_installer');
+  if (!$moduleHandler->moduleExists('environment_indicator')) {
+    $moduleHandler->install(['environment_indicator']);
+  }
+
+  if ($env !== 'production') {
+    $config = \Drupal::configFactory()->getEditable('user.role.authenticated');
+    $permissions = $config->get('permissions') ?? [];
+    if (!in_array('access environment indicator', $permissions)) {
+      $permissions[] = 'access environment indicator';
+      $config->set('permissions', $permissions)->save();
+    }
+  }
+}


### PR DESCRIPTION
### Jira
https://digital-vic.atlassian.net/browse/SD-758
### Problem/Motivation
No indication of current tag deployed on non-prod/prod tide projects.
### Fix
Added config setting to provide relevant tag on tide projects.
### Related PRs
https://github.com/dpc-sdp/bay/pull/362
### Screenshots

### TODO
