### PR TITLE
[SD-745]added helper to add corner graphics

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -448,6 +448,9 @@
             },
             "drupal/tfa_email_otp": {
                 "Disable Verify button on first landing to the tfa form - https://www.drupal.org/project/tfa_email_otp/issues/3469826#comment-15740693": "https://www.drupal.org/files/issues/2024-08-23/3469826-disable-verify-button.patch"
+            },
+            "drupal/admin_toolbar": {
+                "Warning: Trying to access array offset on null in admin_toolbar_toolbar_alter() - https://www.drupal.org/project/admin_toolbar/issues/3525987#comment-16119710": "https://www.drupal.org/files/issues/2025-05-22/admin_toolbar-array-offset-on-null-3525987-12.patch"
             }
         },
         "installer-paths": {

--- a/modules/tide_event/config/install/core.entity_form_display.node.event.default.yml
+++ b/modules/tide_event/config/install/core.entity_form_display.node.event.default.yml
@@ -5,12 +5,14 @@ dependencies:
     - entity_browser.browser.tide_image_browser
     - field.field.node.event.body
     - field.field.node.event.field_audience
+    - field.field.node.event.field_bottom_graphical_image
     - field.field.node.event.field_content_category
     - field.field.node.event.field_custom_filters
     - field.field.node.event.field_event_category
     - field.field.node.event.field_event_description
     - field.field.node.event.field_event_details
     - field.field.node.event.field_featured_image
+    - field.field.node.event.field_graphical_image
     - field.field.node.event.field_landing_page_contact
     - field.field.node.event.field_landing_page_show_contact
     - field.field.node.event.field_landing_page_summary
@@ -165,6 +167,23 @@ third_party_settings:
         required_fields: true
       label: 'Event Author'
       region: content
+    group_customised_header:
+      children:
+        - field_graphical_image
+        - field_bottom_graphical_image
+      label: 'Customised Header'
+      region: content
+      parent_name: group_section_1
+      weight: 9
+      format_type: tab
+      format_settings:
+        classes: ''
+        show_empty_fields: false
+        id: ''
+        label_as_html: false
+        formatter: closed
+        description: ''
+        required_fields: true
 id: node.event.default
 targetEntityType: node
 bundle: event
@@ -194,6 +213,23 @@ content:
     third_party_settings: {  }
     type: entity_reference_autocomplete
     region: content
+  field_bottom_graphical_image:
+    type: entity_browser_entity_reference
+    weight: 19
+    region: content
+    settings:
+      entity_browser: tide_image_browser
+      field_widget_display: rendered_entity
+      field_widget_edit: true
+      field_widget_remove: true
+      field_widget_replace: false
+      open: true
+      field_widget_display_settings:
+        view_mode: media_browser_preview
+      selection_mode: selection_append
+    third_party_settings: {  }
+    visible: true
+    group: group_customised_header
   field_event_category:
     weight: 10
     settings:
@@ -269,6 +305,23 @@ content:
     third_party_settings: {  }
     type: entity_browser_entity_reference
     region: content
+  field_graphical_image:
+    type: entity_browser_entity_reference
+    weight: 18
+    region: content
+    settings:
+      entity_browser: tide_image_browser
+      field_widget_display: rendered_entity
+      field_widget_edit: true
+      field_widget_remove: true
+      field_widget_replace: false
+      open: true
+      field_widget_display_settings:
+        view_mode: media_browser_preview
+      selection_mode: selection_append
+    third_party_settings: {  }
+    visible: true
+    group: group_customised_header
   field_landing_page_contact:
     weight: 8
     settings:

--- a/modules/tide_event/config/install/core.entity_view_display.node.event.default.yml
+++ b/modules/tide_event/config/install/core.entity_view_display.node.event.default.yml
@@ -4,11 +4,13 @@ dependencies:
   config:
     - field.field.node.event.body
     - field.field.node.event.field_audience
+    - field.field.node.event.field_bottom_graphical_image
     - field.field.node.event.field_custom_filters
     - field.field.node.event.field_event_category
     - field.field.node.event.field_event_description
     - field.field.node.event.field_event_details
     - field.field.node.event.field_featured_image
+    - field.field.node.event.field_graphical_image
     - field.field.node.event.field_landing_page_contact
     - field.field.node.event.field_landing_page_show_contact
     - field.field.node.event.field_landing_page_summary

--- a/modules/tide_event/config/install/field.field.node.event.field_bottom_graphical_image.yml
+++ b/modules/tide_event/config/install/field.field.node.event.field_bottom_graphical_image.yml
@@ -1,0 +1,28 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_bottom_graphical_image
+    - media.type.image
+    - node.type.event
+id: node.event.field_bottom_graphical_image
+field_name: field_bottom_graphical_image
+entity_type: node
+bundle: event
+label: 'Bottom corner graphic'
+description: "<p>Corner graphics don't display when a hero image is added.</p><p>See the SDP guide on <a href=\"https://digital-vic.atlassian.net/wiki/spaces/FPSDP/pages/2304212993/Image+ratios+sizes+and+component+use\">image ratios, sizes and component use.</a></p>\r\n"
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:media'
+  handler_settings:
+    target_bundles:
+      image: image
+    sort:
+      field: _none
+      direction: ASC
+    auto_create: false
+    auto_create_bundle: ''
+field_type: entity_reference

--- a/modules/tide_event/config/install/field.field.node.event.field_graphical_image.yml
+++ b/modules/tide_event/config/install/field.field.node.event.field_graphical_image.yml
@@ -1,0 +1,28 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_graphical_image
+    - media.type.image
+    - node.type.event
+id: node.event.field_graphical_image
+field_name: field_graphical_image
+entity_type: node
+bundle: event
+label: 'Top corner graphic'
+description: "<p>Corner graphics don't display when a hero image is added.</p><p>See the SDP guide on <a href=\"https://digital-vic.atlassian.net/wiki/spaces/FPSDP/pages/2304212993/Image+ratios+sizes+and+component+use\">image ratios, sizes and component use.</a></p>\r\n"
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:media'
+  handler_settings:
+    target_bundles:
+      image: image
+    sort:
+      field: _none
+      direction: ASC
+    auto_create: false
+    auto_create_bundle: ''
+field_type: entity_reference

--- a/modules/tide_event/tests/behat/features/fields.feature
+++ b/modules/tide_event/tests/behat/features/fields.feature
@@ -3,9 +3,9 @@ Feature: Fields for Event content type
 
   Ensure that Event content has the expected fields.
 
-  @api
+  @api @javascript
   Scenario: The content type has the expected fields (and labels where we can use them).
-    Given I am logged in as a user with the "create event content" permission
+    Given I am logged in as a user with the "create event content, access toolbar" permissions
     When I visit "node/add/event"
     And save screenshot
     Then I see field "Title"
@@ -45,7 +45,7 @@ Feature: Fields for Event content type
 
     And I should see text matching "Related links"
     And I should see the button "Add Related links" in the "content" region
-    
+
     And I see field "Show Social Sharing?"
     And I should see an "input#edit-field-show-social-sharing-value" element
     And I should not see an "input#edit-field-show-social-sharing-value.required" element
@@ -61,6 +61,8 @@ Feature: Fields for Event content type
     And I should see an "input#edit-field-tags-0-target-id" element
     And I should not see an "input#edit-field-tags-0-target-id.required" element
 
+    nd I click on the horizontal tab "Contact"
+
     And I should see text matching "Contact Us"
     And I should see text matching "No Contact Us block added yet."
     And I should see the button "Add Contact Us" in the "content" region
@@ -69,14 +71,26 @@ Feature: Fields for Event content type
     And I should see an "input#edit-field-show-content-rating-value" element
     And I should not see an "input#edit-field-show-content-rating-value.required" element
 
+    And I click on the horizontal tab "Body Content"
+
     And I should see text matching "Event Details"
     And I should see text matching "Book"
     And I should not see an "input#edit-field-event-details-0-subform-field-paragraph-link-0-uri.required" element
     And I should not see an "input#edit-field-event-details-0-subform-field-paragraph-link-0-title.required" element
-
     And I should see text matching "Website URL"
     And I should see an "input#edit-field-node-link-0-uri" element
     And I should not see an "input#edit-field-node-link-0-uri.required" element
+
+    And I click on the horizontal tab "Customised Header"
+
+    And I select the radio button "Corner graphics"
+    And the "#edit-field-graphical-image" element should contain "Top Corner Graphic"
+    And I should see an "input#edit-field-graphical-image-entity-browser-target" element
+
+    And the "#edit-field-bottom-graphical-image" element should contain "Bottom Corner Graphic"
+    And I should see an "input#edit-field-bottom-graphical-image-entity-browser-target" element
+
+    And I click on the horizontal tab "Event Author"
 
     And I should see text matching "Full Name"
     And I should see an "input#edit-field-node-author-0-value" element

--- a/modules/tide_event/tests/behat/features/fields.feature
+++ b/modules/tide_event/tests/behat/features/fields.feature
@@ -61,7 +61,7 @@ Feature: Fields for Event content type
     And I should see an "input#edit-field-tags-0-target-id" element
     And I should not see an "input#edit-field-tags-0-target-id.required" element
 
-    nd I click on the horizontal tab "Contact"
+    And I click on the horizontal tab "Contact"
 
     And I should see text matching "Contact Us"
     And I should see text matching "No Contact Us block added yet."

--- a/modules/tide_event/tests/behat/features/webform.feature
+++ b/modules/tide_event/tests/behat/features/webform.feature
@@ -5,7 +5,7 @@ Feature: Webform "Event Submission" exists.
 
   @api
   Scenario: The form has the expected fields (and labels where we can use them).
-    Given I am logged in as a user with the "administer webform" permission
+    Given I am logged in as a user with the "administer webform, access toolbar" permission
     When I visit "admin/structure/webform"
     Then I should see the link "Event Submission"
 

--- a/modules/tide_event/tide_event.install
+++ b/modules/tide_event/tide_event.install
@@ -155,3 +155,92 @@ function tide_event_update_10003() {
     ['@webform' => $webform_id]
   );
 }
+
+/**
+ * Add corner graphic fields.
+ */
+function tide_event_update_10004() {
+  $configs = [
+    'field.field.node.event.field_bottom_graphical_image' => 'field_config',
+    'field.field.node.event.field_graphical_image' => 'field_config',
+  ];
+  \Drupal::moduleHandler()->loadInclude('tide_core', 'inc', 'includes/helpers');
+  $config_location = [\Drupal::service('extension.list.module')->getPath('tide_event') . '/config/install'];
+  // Check if field already exported to config/sync.
+  foreach ($configs as $config => $type) {
+    $config_read = _tide_read_config($config, $config_location, TRUE);
+    $storage = \Drupal::entityTypeManager()->getStorage($type);
+    $id = $storage->getIDFromConfigName($config, $storage->getEntityType()->getConfigPrefix());
+    if ($storage->load($id) == NULL) {
+      $config_entity = $storage->createFromStorageRecord($config_read);
+      $config_entity->save();
+    }
+  }
+
+  // Load the form display entity.
+  $form_display_id = 'node.event.default';
+  $form_display = \Drupal::entityTypeManager()
+    ->getStorage('entity_form_display')
+    ->load($form_display_id);
+
+  if (!$form_display) {
+    return;
+  }
+
+  // Common settings for Entity Browser widget.
+  $widget_base = [
+    'type' => 'entity_browser_entity_reference',
+    'region' => 'content',
+    'settings' => [
+      'entity_browser' => 'tide_image_browser',
+      'field_widget_display' => 'rendered_entity',
+      'field_widget_edit' => TRUE,
+      'field_widget_remove' => TRUE,
+      'field_widget_replace' => FALSE,
+      'open' => TRUE,
+      'field_widget_display_settings' => [
+        'view_mode' => 'media_browser_preview',
+      ],
+      'selection_mode' => 'selection_append',
+    ],
+    'third_party_settings' => [],
+    'visible' => TRUE,
+    'group' => 'group_customised_header',
+  ];
+
+  // Apply individual weights and set component config.
+  $fields = [
+    'field_graphical_image' => 18,
+    'field_bottom_graphical_image' => 19,
+  ];
+
+  foreach ($fields as $field => $weight) {
+    $component = $widget_base;
+    $component['weight'] = $weight;
+    $form_display->setComponent($field, $component);
+  }
+
+  // Define the field group using field_group's third-party settings.
+  $form_display->setThirdPartySetting('field_group', 'group_customised_header', [
+    'children' => [
+      'field_graphical_image',
+      'field_bottom_graphical_image',
+    ],
+    'label' => 'Customised Header',
+    'region' => 'content',
+    'parent_name' => 'group_section_1',
+    'weight' => 9,
+    'format_type' => 'tab',
+    'format_settings' => [
+      'classes' => '',
+      'show_empty_fields' => FALSE,
+      'id' => '',
+      'label_as_html' => FALSE,
+      'formatter' => 'closed',
+      'description' => '',
+      'required_fields' => TRUE,
+    ],
+  ]);
+
+  $form_display->save();
+}

--- a/modules/tide_event/tide_event.module
+++ b/modules/tide_event/tide_event.module
@@ -12,8 +12,55 @@ use Drupal\node\Entity\Node;
 use Drupal\paragraphs\Entity\Paragraph;
 use Drupal\search_api\IndexInterface;
 use Drupal\smart_trim\TruncateHTML;
+use Drupal\tide_core\TideCoreFormHelper;
 use Drupal\user\Entity\Role;
 use Drupal\workflows\Entity\Workflow;
+
+/**
+ * Node form #process callback.
+ *
+ * @param array $form
+ *   Form that is being processed.
+ * @param \Drupal\Core\Form\FormStateInterface $form_state
+ *   The current state of the form.
+ * @param array $complete_form
+ *   The complete form.
+ *
+ * @return array
+ *   The processed form.
+ */
+function _tide_event_form_node_form_process(array $form, FormStateInterface $form_state, array $complete_form = []) {
+  /** @var \Drupal\node\NodeInterface $node */
+  $node = $form_state->getFormObject()->getEntity();
+  TideCoreFormHelper::addHeaderStyleSelector($form, $form_state, $node, [
+    'group' => 'group_customised_header',
+    'fields' => [
+      'field_graphical_image',
+      'field_bottom_graphical_image',
+    ],
+    'after_build' => '_tide_event_form_node_form_after_build',
+  ]);
+  return $form;
+}
+
+/**
+ * Node form #after_build callback.
+ *
+ * @param array $form
+ *   Form that is being processed.
+ * @param \Drupal\Core\Form\FormStateInterface $form_state
+ *   The current state of the form.
+ *
+ * @return array
+ *   The processed form.
+ */
+function _tide_event_form_node_form_after_build(array $form, FormStateInterface $form_state) {
+  return TideCoreFormHelper::updateHeaderStyleFromState($form, $form_state, [
+    'field_graphical_image',
+    'field_bottom_graphical_image',
+  ]);
+  return $form;
+}
 
 /**
  * Implements hook_entity_bundle_create().
@@ -71,6 +118,7 @@ function tide_event_form_node_form_alter(&$form, FormStateInterface $form_state,
     ) {
       $form['field_custom_filters']['#access'] = FALSE;
     }
+    $form['#process'][] = '_tide_event_form_node_form_process';
   }
 }
 
@@ -157,7 +205,7 @@ function tide_event_webform_submission_presave($submission) {
       ],
       'field_paragraph_date_range' => [
         [
-          'value' => date('Y-m-d\TH:i:00', strtotime(Html::escape($submission_data['open_date']))) ,
+          'value' => date('Y-m-d\TH:i:00', strtotime(Html::escape($submission_data['open_date']))),
           'end_value' => date('Y-m-d\TH:i:00', strtotime(Html::escape($submission_data['close_date']))),
         ],
       ],

--- a/modules/tide_event/tide_event.module
+++ b/modules/tide_event/tide_event.module
@@ -59,7 +59,6 @@ function _tide_event_form_node_form_after_build(array $form, FormStateInterface 
     'field_graphical_image',
     'field_bottom_graphical_image',
   ]);
-  return $form;
 }
 
 /**

--- a/modules/tide_grant/config/install/core.entity_form_display.node.grant.default.yml
+++ b/modules/tide_grant/config/install/core.entity_form_display.node.grant.default.yml
@@ -4,10 +4,12 @@ dependencies:
   config:
     - entity_browser.browser.tide_document_browser
     - field.field.node.grant.field_audience
+    - field.field.node.grant.field_bottom_graphical_image
     - field.field.node.grant.field_call_to_action
     - field.field.node.grant.field_custom_filters
     - field.field.node.grant.field_description
     - field.field.node.grant.field_featured_image
+    - field.field.node.grant.field_graphical_image
     - field.field.node.grant.field_landing_page_contact
     - field.field.node.grant.field_landing_page_intro_text
     - field.field.node.grant.field_landing_page_nav_title
@@ -228,6 +230,23 @@ third_party_settings:
         classes: ''
       region: content
       weight: -50
+    group_customised_header:
+      children:
+        - field_graphical_image
+        - field_bottom_graphical_image
+      label: 'Customised Header'
+      region: content
+      parent_name: group_section_header
+      weight: 9
+      format_type: tab
+      format_settings:
+        classes: ''
+        show_empty_fields: false
+        id: ''
+        label_as_html: false
+        formatter: closed
+        description: ''
+        required_fields: true
 id: node.grant.default
 targetEntityType: node
 bundle: grant
@@ -249,6 +268,23 @@ content:
     third_party_settings: {  }
     type: entity_reference_autocomplete
     region: content
+  field_bottom_graphical_image:
+    type: entity_browser_entity_reference
+    weight: 19
+    region: content
+    settings:
+      entity_browser: tide_image_browser
+      field_widget_display: rendered_entity
+      field_widget_edit: true
+      field_widget_remove: true
+      field_widget_replace: false
+      open: true
+      field_widget_display_settings:
+        view_mode: media_browser_preview
+      selection_mode: selection_append
+    third_party_settings: {  }
+    visible: true
+    group: group_customised_header
   field_call_to_action:
     weight: 20
     settings:
@@ -300,6 +336,23 @@ content:
     third_party_settings: {  }
     type: entity_browser_entity_reference
     region: content
+  field_graphical_image:
+    type: entity_browser_entity_reference
+    weight: 18
+    region: content
+    settings:
+      entity_browser: tide_image_browser
+      field_widget_display: rendered_entity
+      field_widget_edit: true
+      field_widget_remove: true
+      field_widget_replace: false
+      open: true
+      field_widget_display_settings:
+        view_mode: media_browser_preview
+      selection_mode: selection_append
+    third_party_settings: {  }
+    visible: true
+    group: group_customised_header
   field_landing_page_contact:
     weight: 10
     settings:

--- a/modules/tide_grant/config/install/core.entity_view_display.node.grant.default.yml
+++ b/modules/tide_grant/config/install/core.entity_view_display.node.grant.default.yml
@@ -3,10 +3,12 @@ status: true
 dependencies:
   config:
     - field.field.node.grant.field_audience
+    - field.field.node.grant.field_bottom_graphical_image
     - field.field.node.grant.field_call_to_action
     - field.field.node.grant.field_custom_filters
     - field.field.node.grant.field_description
     - field.field.node.grant.field_featured_image
+    - field.field.node.grant.field_graphical_image
     - field.field.node.grant.field_landing_page_contact
     - field.field.node.grant.field_landing_page_intro_text
     - field.field.node.grant.field_landing_page_nav_title

--- a/modules/tide_grant/config/install/field.field.node.grant.field_bottom_graphical_image.yml
+++ b/modules/tide_grant/config/install/field.field.node.grant.field_bottom_graphical_image.yml
@@ -1,0 +1,28 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_bottom_graphical_image
+    - media.type.image
+    - node.type.grant
+id: node.grant.field_bottom_graphical_image
+field_name: field_bottom_graphical_image
+entity_type: node
+bundle: grant
+label: 'Bottom corner graphic'
+description: "<p>Corner graphics don't display when a hero image is added.</p><p>See the SDP guide on <a href=\"https://digital-vic.atlassian.net/wiki/spaces/FPSDP/pages/2304212993/Image+ratios+sizes+and+component+use\">image ratios, sizes and component use.</a></p>\r\n"
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:media'
+  handler_settings:
+    target_bundles:
+      image: image
+    sort:
+      field: _none
+      direction: ASC
+    auto_create: false
+    auto_create_bundle: ''
+field_type: entity_reference

--- a/modules/tide_grant/config/install/field.field.node.grant.field_graphical_image.yml
+++ b/modules/tide_grant/config/install/field.field.node.grant.field_graphical_image.yml
@@ -1,0 +1,28 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_graphical_image
+    - media.type.image
+    - node.type.grant
+id: node.grant.field_graphical_image
+field_name: field_graphical_image
+entity_type: node
+bundle: grant
+label: 'Top corner graphic'
+description: "<p>Corner graphics don't display when a hero image is added.</p><p>See the SDP guide on <a href=\"https://digital-vic.atlassian.net/wiki/spaces/FPSDP/pages/2304212993/Image+ratios+sizes+and+component+use\">image ratios, sizes and component use.</a></p>\r\n"
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:media'
+  handler_settings:
+    target_bundles:
+      image: image
+    sort:
+      field: _none
+      direction: ASC
+    auto_create: false
+    auto_create_bundle: ''
+field_type: entity_reference

--- a/modules/tide_grant/tests/behat/features/fields.feature
+++ b/modules/tide_grant/tests/behat/features/fields.feature
@@ -5,7 +5,7 @@ Feature: Fields for Grant content type
 
   @api @javascript
   Scenario: The content type has the expected fields (and labels where we can use them).
-    Given I am logged in as a user with the "create grant content" permission
+    Given I am logged in as a user with the "create grant content, access toolbar" permission
     When I visit "node/add/grant"
     And save screenshot
     Then I see field "Title"
@@ -47,6 +47,15 @@ Feature: Fields for Grant content type
     And I click on the horizontal tab "Grant Author"
     And I see field "Department"
     And I should see an "select#edit-field-node-department" element
+
+    And I click on the horizontal tab "Customised Header"
+    And I select the radio button "Corner graphics"
+
+    And the "#edit-field-graphical-image" element should contain "Top Corner Graphic"
+    And I should see an "input#edit-field-graphical-image-entity-browser-target" element
+
+    And the "#edit-field-bottom-graphical-image" element should contain "Bottom Corner Graphic"
+    And I should see an "input#edit-field-bottom-graphical-image-entity-browser-target" element
 
     And I click on the horizontal tab "Grant timeline"
     Then I should see an "#edit-field-node-timeline-0-top-type" element

--- a/modules/tide_grant/tide_grant.install
+++ b/modules/tide_grant/tide_grant.install
@@ -110,3 +110,93 @@ function tide_grant_update_10002() {
     ])
     ->save();
 }
+
+
+/**
+ * Add corner graphic fields.
+ */
+function tide_grant_update_10003() {
+  $configs = [
+    'field.field.node.grant.field_bottom_graphical_image' => 'field_config',
+    'field.field.node.grant.field_graphical_image' => 'field_config',
+  ];
+  \Drupal::moduleHandler()->loadInclude('tide_core', 'inc', 'includes/helpers');
+  $config_location = [\Drupal::service('extension.list.module')->getPath('tide_grant') . '/config/install'];
+  // Check if field already exported to config/sync.
+  foreach ($configs as $config => $type) {
+    $config_read = _tide_read_config($config, $config_location, TRUE);
+    $storage = \Drupal::entityTypeManager()->getStorage($type);
+    $id = $storage->getIDFromConfigName($config, $storage->getEntityType()->getConfigPrefix());
+    if ($storage->load($id) == NULL) {
+      $config_entity = $storage->createFromStorageRecord($config_read);
+      $config_entity->save();
+    }
+  }
+
+  // Load the form display entity.
+  $form_display_id = 'node.grant.default';
+  $form_display = \Drupal::entityTypeManager()
+    ->getStorage('entity_form_display')
+    ->load($form_display_id);
+
+  if (!$form_display) {
+    return;
+  }
+
+  // Common settings for Entity Browser widget.
+  $widget_base = [
+    'type' => 'entity_browser_entity_reference',
+    'region' => 'content',
+    'settings' => [
+      'entity_browser' => 'tide_image_browser',
+      'field_widget_display' => 'rendered_entity',
+      'field_widget_edit' => TRUE,
+      'field_widget_remove' => TRUE,
+      'field_widget_replace' => FALSE,
+      'open' => TRUE,
+      'field_widget_display_settings' => [
+        'view_mode' => 'media_browser_preview',
+      ],
+      'selection_mode' => 'selection_append',
+    ],
+    'third_party_settings' => [],
+    'visible' => TRUE,
+    'group' => 'group_customised_header',
+  ];
+
+  // Apply individual weights and set component config.
+  $fields = [
+    'field_graphical_image' => 18,
+    'field_bottom_graphical_image' => 19,
+  ];
+
+  foreach ($fields as $field => $weight) {
+    $component = $widget_base;
+    $component['weight'] = $weight;
+    $form_display->setComponent($field, $component);
+  }
+
+  // Define the field group using field_group's third-party settings.
+  $form_display->setThirdPartySetting('field_group', 'group_customised_header', [
+    'children' => [
+      'field_graphical_image',
+      'field_bottom_graphical_image',
+    ],
+    'label' => 'Customised Header',
+    'region' => 'content',
+    'parent_name' => 'group_section_header',
+    'weight' => 9,
+    'format_type' => 'tab',
+    'format_settings' => [
+      'classes' => '',
+      'show_empty_fields' => FALSE,
+      'id' => '',
+      'label_as_html' => FALSE,
+      'formatter' => 'closed',
+      'description' => '',
+      'required_fields' => TRUE,
+    ],
+  ]);
+
+  $form_display->save();
+}

--- a/modules/tide_grant/tide_grant.install
+++ b/modules/tide_grant/tide_grant.install
@@ -111,7 +111,6 @@ function tide_grant_update_10002() {
     ->save();
 }
 
-
 /**
  * Add corner graphic fields.
  */

--- a/modules/tide_grant/tide_grant.module
+++ b/modules/tide_grant/tide_grant.module
@@ -9,6 +9,7 @@ use Drupal\Component\Utility\UrlHelper;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\node\Entity\Node;
 use Drupal\node\NodeInterface;
+use Drupal\tide_core\TideCoreFormHelper;
 
 /**
  * Implements hook_form_BASE_FORM_ID_alter().
@@ -22,6 +23,7 @@ function tide_grant_form_node_form_alter(&$form, FormStateInterface $form_state,
     if (
       (
         is_array($settings['handler_settings'])
+        && isset($settings['handler_settings']['target_bundles'])
         && !is_array($settings['handler_settings']['target_bundles'])
       )
       || empty($settings['handler_settings'])
@@ -94,6 +96,16 @@ function tide_grant_form_node_form_alter(&$form, FormStateInterface $form_state,
  *   The processed form.
  */
 function _tide_grant_form_node_form_process(array $form, FormStateInterface $form_state, array $complete_form = []) {
+  /** @var \Drupal\node\NodeInterface $node */
+  $node = $form_state->getFormObject()->getEntity();
+  TideCoreFormHelper::addHeaderStyleSelector($form, $form_state, $node, [
+    'group' => 'group_customised_header',
+    'fields' => [
+      'field_graphical_image',
+      'field_bottom_graphical_image',
+    ],
+  ]);
+
   $form['field_node_department']['#group'] = 'group_grant_author';
   $form['field_node_department']['#weight'] = 50;
 
@@ -115,10 +127,13 @@ function _tide_grant_form_node_form_process(array $form, FormStateInterface $for
  *   The processed form.
  */
 function _tide_grant_form_node_form_after_build(array $form, FormStateInterface $form_state) {
+  return TideCoreFormHelper::updateHeaderStyleFromState($form, $form_state, [
+    'field_graphical_image',
+    'field_bottom_graphical_image',
+  ]);
+
   $form['field_node_department']['#group'] = 'group_grant_author';
   $form['field_node_department']['#weight'] = 50;
-
-  return $form;
 }
 
 /**

--- a/modules/tide_grant/tide_grant.module
+++ b/modules/tide_grant/tide_grant.module
@@ -127,13 +127,12 @@ function _tide_grant_form_node_form_process(array $form, FormStateInterface $for
  *   The processed form.
  */
 function _tide_grant_form_node_form_after_build(array $form, FormStateInterface $form_state) {
+  $form['field_node_department']['#group'] = 'group_grant_author';
+  $form['field_node_department']['#weight'] = 50;
   return TideCoreFormHelper::updateHeaderStyleFromState($form, $form_state, [
     'field_graphical_image',
     'field_bottom_graphical_image',
   ]);
-
-  $form['field_node_department']['#group'] = 'group_grant_author';
-  $form['field_node_department']['#weight'] = 50;
 }
 
 /**

--- a/modules/tide_news/config/install/core.entity_form_display.node.news.default.yml
+++ b/modules/tide_news/config/install/core.entity_form_display.node.news.default.yml
@@ -4,8 +4,10 @@ dependencies:
   config:
     - entity_browser.browser.tide_image_browser
     - field.field.node.news.body
+    - field.field.node.news.field_bottom_graphical_image
     - field.field.node.news.field_custom_filters
     - field.field.node.news.field_featured_image
+    - field.field.node.news.field_graphical_image
     - field.field.node.news.field_landing_page_contact
     - field.field.node.news.field_landing_page_nav_title
     - field.field.node.news.field_landing_page_show_contact
@@ -187,6 +189,23 @@ third_party_settings:
         open: false
         required_fields: true
       label: 'Site-section Navigation'
+    group_customised_header:
+      children:
+        - field_graphical_image
+        - field_bottom_graphical_image
+      label: 'Customised Header'
+      region: content
+      parent_name: group_section_header
+      weight: 9
+      format_type: tab
+      format_settings:
+        classes: ''
+        show_empty_fields: false
+        id: ''
+        label_as_html: false
+        formatter: closed
+        description: ''
+        required_fields: true
 id: node.news.default
 targetEntityType: node
 bundle: news
@@ -243,6 +262,23 @@ content:
     third_party_settings: {  }
     type: entity_browser_entity_reference
     region: content
+  field_graphical_image:
+    type: entity_browser_entity_reference
+    weight: 18
+    region: content
+    settings:
+      entity_browser: tide_image_browser
+      field_widget_display: rendered_entity
+      field_widget_edit: true
+      field_widget_remove: true
+      field_widget_replace: false
+      open: true
+      field_widget_display_settings:
+        view_mode: media_browser_preview
+      selection_mode: selection_append
+    third_party_settings: {  }
+    visible: true
+    group: group_customised_header
   field_landing_page_contact:
     weight: 10
     settings:
@@ -390,6 +426,23 @@ content:
     third_party_settings: {  }
     type: entity_reference_autocomplete
     region: content
+  field_bottom_graphical_image:
+    type: entity_browser_entity_reference
+    weight: 19
+    region: content
+    settings:
+      entity_browser: tide_image_browser
+      field_widget_display: rendered_entity
+      field_widget_edit: true
+      field_widget_remove: true
+      field_widget_replace: false
+      open: true
+      field_widget_display_settings:
+        view_mode: media_browser_preview
+      selection_mode: selection_append
+    third_party_settings: {  }
+    visible: true
+    group: group_customised_header
   field_content_category:
     type: term_reference_tree
     weight: 1

--- a/modules/tide_news/config/install/core.entity_view_display.node.news.default.yml
+++ b/modules/tide_news/config/install/core.entity_view_display.node.news.default.yml
@@ -3,8 +3,10 @@ status: true
 dependencies:
   config:
     - field.field.node.news.body
+    - field.field.node.news.field_bottom_graphical_image
     - field.field.node.news.field_custom_filters
     - field.field.node.news.field_featured_image
+    - field.field.node.news.field_graphical_image
     - field.field.node.news.field_landing_page_nav_title
     - field.field.node.news.field_location
     - field.field.node.news.field_metatags

--- a/modules/tide_news/config/install/field.field.node.news.field_bottom_graphical_image.yml
+++ b/modules/tide_news/config/install/field.field.node.news.field_bottom_graphical_image.yml
@@ -1,0 +1,28 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_bottom_graphical_image
+    - media.type.image
+    - node.type.news
+id: node.news.field_bottom_graphical_image
+field_name: field_bottom_graphical_image
+entity_type: node
+bundle: news
+label: 'Bottom corner graphic'
+description: '<p>Corner graphics don''t display when a hero image is added.</p><p>See the SDP guide on <a href="https://digital-vic.atlassian.net/wiki/spaces/FPSDP/pages/2304212993/Image+ratios+sizes+and+component+use">image ratios, sizes and component use.</a></p>'
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:media'
+  handler_settings:
+    target_bundles:
+      image: image
+    sort:
+      field: _none
+      direction: ASC
+    auto_create: false
+    auto_create_bundle: ''
+field_type: entity_reference

--- a/modules/tide_news/config/install/field.field.node.news.field_graphical_image.yml
+++ b/modules/tide_news/config/install/field.field.node.news.field_graphical_image.yml
@@ -1,0 +1,28 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_graphical_image
+    - media.type.image
+    - node.type.news
+id: node.news.field_graphical_image
+field_name: field_graphical_image
+entity_type: node
+bundle: news
+label: 'Top corner graphic'
+description: "<p>Corner graphics don't display when a hero image is added.</p><p>See the SDP guide on <a href=\"https://digital-vic.atlassian.net/wiki/spaces/FPSDP/pages/2304212993/Image+ratios+sizes+and+component+use\">image ratios, sizes and component use.</a></p>\r\n"
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:media'
+  handler_settings:
+    target_bundles:
+      image: image
+    sort:
+      field: _none
+      direction: ASC
+    auto_create: false
+    auto_create_bundle: ''
+field_type: entity_reference

--- a/modules/tide_news/tests/behat/features/fields.feature
+++ b/modules/tide_news/tests/behat/features/fields.feature
@@ -5,7 +5,7 @@ Feature: Fields for News content type
 
   @api @javascript
   Scenario: The content type has the expected fields (and labels where we can use them).
-    Given I am logged in as a user with the "create news content" permission
+    Given I am logged in as a user with the "create news content, access toolbar" permission
     When I visit "node/add/news"
     And save screenshot
     Then I see field "Title"
@@ -18,6 +18,14 @@ Feature: Fields for News content type
     And I see field "Introduction Text"
     And I should see an "textarea#edit-field-news-intro-text-0-value" element
     And I should not see an "textarea#edit-field-news-intro-text-0-value.required" element
+
+    And I click on the horizontal tab "Customised Header"
+    And I select the radio button "Corner graphics"
+    And the "#edit-field-graphical-image" element should contain "Top Corner Graphic"
+    And I should see an "input#edit-field-graphical-image-entity-browser-target" element
+
+    And the "#edit-field-bottom-graphical-image" element should contain "Bottom Corner Graphic"
+    And I should see an "input#edit-field-bottom-graphical-image-entity-browser-target" element
 
     And the "#edit-field-featured-image" element should contain "Featured Image"
     And I should see an "input#edit-field-featured-image-entity-browser-entity-browser-open-modal" element

--- a/modules/tide_news/tide_news.install
+++ b/modules/tide_news/tide_news.install
@@ -91,3 +91,92 @@ function tide_news_update_10002() {
     ])
     ->save();
 }
+
+/**
+ * Add corner graphic fields.
+ */
+function tide_news_update_10003() {
+  $configs = [
+    'field.field.node.news.field_bottom_graphical_image' => 'field_config',
+    'field.field.node.news.field_graphical_image' => 'field_config',
+  ];
+  \Drupal::moduleHandler()->loadInclude('tide_core', 'inc', 'includes/helpers');
+  $config_location = [\Drupal::service('extension.list.module')->getPath('tide_news') . '/config/install'];
+  // Check if field already exported to config/sync.
+  foreach ($configs as $config => $type) {
+    $config_read = _tide_read_config($config, $config_location, TRUE);
+    $storage = \Drupal::entityTypeManager()->getStorage($type);
+    $id = $storage->getIDFromConfigName($config, $storage->getEntityType()->getConfigPrefix());
+    if ($storage->load($id) == NULL) {
+      $config_entity = $storage->createFromStorageRecord($config_read);
+      $config_entity->save();
+    }
+  }
+
+  // Load the form display entity.
+  $form_display_id = 'node.news.default';
+  $form_display = \Drupal::entityTypeManager()
+    ->getStorage('entity_form_display')
+    ->load($form_display_id);
+
+  if (!$form_display) {
+    return;
+  }
+
+  // Common settings for Entity Browser widget.
+  $widget_base = [
+    'type' => 'entity_browser_entity_reference',
+    'region' => 'content',
+    'settings' => [
+      'entity_browser' => 'tide_image_browser',
+      'field_widget_display' => 'rendered_entity',
+      'field_widget_edit' => TRUE,
+      'field_widget_remove' => TRUE,
+      'field_widget_replace' => FALSE,
+      'open' => TRUE,
+      'field_widget_display_settings' => [
+        'view_mode' => 'media_browser_preview',
+      ],
+      'selection_mode' => 'selection_append',
+    ],
+    'third_party_settings' => [],
+    'visible' => TRUE,
+    'group' => 'group_customised_header',
+  ];
+
+  // Apply individual weights and set component config.
+  $fields = [
+    'field_graphical_image' => 18,
+    'field_bottom_graphical_image' => 19,
+  ];
+
+  foreach ($fields as $field => $weight) {
+    $component = $widget_base;
+    $component['weight'] = $weight;
+    $form_display->setComponent($field, $component);
+  }
+
+  // Define the field group using field_group's third-party settings.
+  $form_display->setThirdPartySetting('field_group', 'group_customised_header', [
+    'children' => [
+      'field_graphical_image',
+      'field_bottom_graphical_image',
+    ],
+    'label' => 'Customised Header',
+    'region' => 'content',
+    'parent_name' => 'group_section_header',
+    'weight' => 9,
+    'format_type' => 'tab',
+    'format_settings' => [
+      'classes' => '',
+      'show_empty_fields' => FALSE,
+      'id' => '',
+      'label_as_html' => FALSE,
+      'formatter' => 'closed',
+      'description' => '',
+      'required_fields' => TRUE,
+    ],
+  ]);
+
+  $form_display->save();
+}

--- a/modules/tide_news/tide_news.module
+++ b/modules/tide_news/tide_news.module
@@ -7,6 +7,7 @@
 
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Render\Element;
+use Drupal\tide_core\TideCoreFormHelper;
 use Drupal\workflows\Entity\Workflow;
 
 /**
@@ -91,6 +92,14 @@ function tide_news_form_node_form_alter(&$form, FormStateInterface $form_state, 
 function _tide_news_form_node_form_process(array $form, FormStateInterface $form_state, array $complete_form = []) {
   /** @var \Drupal\node\NodeInterface $node */
   $node = $form_state->getFormObject()->getEntity();
+  TideCoreFormHelper::addHeaderStyleSelector($form, $form_state, $node, [
+    'group' => 'group_customised_header',
+    'fields' => [
+      'field_graphical_image',
+      'field_bottom_graphical_image',
+    ],
+    'after_build' => '_tide_event_form_node_form_after_build',
+  ]);
 
   $form['field_node_department']['#group'] = 'group_author_detail';
 
@@ -112,7 +121,10 @@ function _tide_news_form_node_form_process(array $form, FormStateInterface $form
  *   The processed form.
  */
 function _tide_news_form_node_form_after_build(array $form, FormStateInterface $form_state) {
+  return TideCoreFormHelper::updateHeaderStyleFromState($form, $form_state, [
+    'field_graphical_image',
+    'field_bottom_graphical_image',
+  ]);
   $form['field_node_department']['#group'] = 'group_author_detail';
-
   return $form;
 }

--- a/modules/tide_news/tide_news.module
+++ b/modules/tide_news/tide_news.module
@@ -121,10 +121,9 @@ function _tide_news_form_node_form_process(array $form, FormStateInterface $form
  *   The processed form.
  */
 function _tide_news_form_node_form_after_build(array $form, FormStateInterface $form_state) {
+  $form['field_node_department']['#group'] = 'group_author_detail';
   return TideCoreFormHelper::updateHeaderStyleFromState($form, $form_state, [
     'field_graphical_image',
     'field_bottom_graphical_image',
   ]);
-  $form['field_node_department']['#group'] = 'group_author_detail';
-  return $form;
 }

--- a/modules/tide_publication/tests/behat/features/fields.feature
+++ b/modules/tide_publication/tests/behat/features/fields.feature
@@ -5,8 +5,7 @@ Feature: Fields for Publication content type
 
   @api @javascript
   Scenario: The content type has the expected fields (and labels where we can use them).
-    # Given I am logged in as a user with the "editor" role
-    Given I am logged in as a user with the "create publication content" permission
+    Given I am logged in as a user with the "create publication content, access toolbar" permission
     When I visit "node/add/publication"
     And save screenshot
 
@@ -66,7 +65,7 @@ Feature: Fields for Publication content type
     And I should see the button "Accordion"
     And I should see the button "Complex image"
     And I should see the button "Reusable content item"
-    And I should see the button "Statics Grid"
+    And I should see the button "Statistics Grid"
     And I press the "Close" button
 
     And I scroll selector "#edit-group-sidebar" into view
@@ -175,7 +174,7 @@ Feature: Fields for Publication content type
     And I should see the button "Complex image"
     And I should see the button "Form embed (Drupal)"
     And I should see the button "Timelines"
-    And I should see the button "Statics grid"
+    And I should see the button "Statistics grid"
     And I should see the button "Reusable content item"
     And I press the "Close" button
 

--- a/src/TideCoreFormHelper.php
+++ b/src/TideCoreFormHelper.php
@@ -1,0 +1,104 @@
+<?php
+
+namespace Drupal\tide_core;
+
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\node\NodeInterface;
+use Drupal\Core\StringTranslation\TranslatableMarkup;
+
+/**
+ * Helper functions for altering node forms.
+ */
+class TideCoreFormHelper {
+
+  /**
+   * Adds a header style radio selector with conditional visibility logic.
+   *
+   * @param array $form
+   *   The form array.
+   * @param \Drupal\Core\Form\FormStateInterface $form_state
+   *   The form state.
+   * @param \Drupal\node\NodeInterface $node
+   *   The node entity.
+   * @param array $settings
+   *   Associative array with:
+   *   - 'group': Group ID to attach the container to.
+   *   - 'fields': Array of field machine names to show/hide.
+   *   - 'after_build': (optional) After-build callback function name.
+   */
+  public static function addHeaderStyleSelector(array &$form, FormStateInterface $form_state, NodeInterface $node, array $settings) {
+    $group = $settings['group'] ?? 'group_customised_header';
+    $fields = $settings['fields'] ?? [];
+    $after_build = $settings['after_build'] ?? NULL;
+
+    $form['_header_style'] = [
+      '#type' => 'container',
+      '#group' => $group,
+      '#weight' => -100,
+    ];
+
+    $form['_header_style']['_header_style_options'] = [
+      '#title' => new TranslatableMarkup('Header style'),
+      '#description' => new TranslatableMarkup('The header can be customised to incorporate corner graphics.'),
+      '#type' => 'radios',
+      '#required' => TRUE,
+      '#options' => [
+        'default' => new TranslatableMarkup('Default appearance'),
+        'corner' => new TranslatableMarkup('Corner graphics'),
+      ],
+    ];
+
+    // Set default value based on image field presence.
+    $header_style = 'default';
+    foreach ($fields as $field) {
+      if ($node->hasField($field) && !$node->get($field)->isEmpty()) {
+        $header_style = 'corner';
+        break;
+      }
+    }
+
+    $form['_header_style']['_header_style_options']['#default_value'] = $header_style;
+
+    // Add visibility states to the specified fields.
+    foreach ($fields as $field) {
+      if (isset($form[$field])) {
+        $form[$field]['#states']['visible'] = [
+          ':input[name="_header_style_options"]' => ['value' => 'corner'],
+        ];
+      }
+    }
+
+    if ($after_build) {
+      $form['#after_build'][] = $after_build;
+    }
+  }
+
+  /**
+   * Updates the default header style based on form state field values.
+   *
+   * @param array $form
+   *   The form array.
+   * @param \Drupal\Core\Form\FormStateInterface $form_state
+   *   The form state.
+   * @param string[] $fields
+   *   The list of image fields to check.
+   *
+   * @return array
+   *   The updated form array.
+   */
+  public static function updateHeaderStyleFromState(array $form, FormStateInterface $form_state, array $fields) {
+    $header_style = 'default';
+
+    foreach ($fields as $field) {
+      $target_id = $form_state->getValue([$field, 'target_id']);
+      if (!empty($target_id)) {
+        $header_style = 'corner';
+        break;
+      }
+    }
+
+    $form['_header_style']['_header_style_options']['#default_value'] = $header_style;
+
+    return $form;
+  }
+}

--- a/src/TideCoreFormHelper.php
+++ b/src/TideCoreFormHelper.php
@@ -3,8 +3,8 @@
 namespace Drupal\tide_core;
 
 use Drupal\Core\Form\FormStateInterface;
-use Drupal\node\NodeInterface;
 use Drupal\Core\StringTranslation\TranslatableMarkup;
+use Drupal\node\NodeInterface;
 
 /**
  * Helper functions for altering node forms.
@@ -101,4 +101,5 @@ class TideCoreFormHelper {
 
     return $form;
   }
+
 }


### PR DESCRIPTION
### Jira
https://digital-vic.atlassian.net/browse/SD-745
https://digital-vic.atlassian.net/browse/SD-744
https://digital-vic.atlassian.net/browse/SD-743

Testing link: https://nginx-php.pr-550.content-reference-sdp-vic-gov-au.sdp4.sdp.vic.gov.au/
### Problem/Motivation
allow users to add a top and / or bottom corner graphic to the news item content type

if top and / or bottom corner graphic images are added, this will over ride any site or site section images

if no top and / or bottom corner graphic, then it is expected that the site section or site top and / or bottom corner graphics will be used 


### Fix
Create a helper functions for altering node forms.
Added top and bottom corner graphics in news, event, grant.
Updated behat tests
Added hook update .
Adding patch for admin_toolbar module as 2 days ago there was a new release for that module which was causing issues when running behat tests. https://www.drupal.org/project/admin_toolbar/issues/3525987
### Related PRs

### Screenshots

<img width="920" alt="Screenshot 2025-05-23 at 11 24 04 am" src="https://github.com/user-attachments/assets/c2a7600a-d056-4959-9e61-52c6a53f0278" />
<img width="872" alt="Screenshot 2025-05-23 at 10 24 08 am" src="https://github.com/user-attachments/assets/1f42e23f-59a1-49c0-b783-c49354113d94" />
<img width="914" alt="Screenshot 2025-05-23 at 11 25 23 am" src="https://github.com/user-attachments/assets/30593eb2-52ca-4269-a0b6-bc9ed63d19d9" />

### TODO
