### PR TITLE
remove patch jsoapi menu items

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -436,9 +436,6 @@
             "drupal/jsonapi_extras": {
                 "Make max value of page[limit] configurable per entity/bundle - https://www.drupal.org/project/jsonapi_extras/issues/2884292#comment-14794882": "https://www.drupal.org/files/issues/2022-11-21/max_page_limit_configuration-2884292-33.patch"
             },
-            "drupal/jsonapi_menu_items": {
-                "Allow filtering of response payload - https://www.drupal.org/project/jsonapi_menu_items/issues/3350524#comment-15577964": "https://www.drupal.org/files/issues/2024-05-02/3350524-filter_fields-6.patch"
-            },
             "drupal/linkit": {
                 "Unpublished nodes not included even when option is selected - https://www.drupal.org/project/linkit/issues/3049946#comment-14953079": "https://www.drupal.org/files/issues/2023-03-06/linkit-unpublished-nodes-not-included-3049946-32.patch"
             },


### PR DESCRIPTION
### Jira

### Problem/Motivation
Yesterday a new release for JSON:API Menu Items has been launched and this [patch](https://www.drupal.org/project/jsonapi_menu_items/issues/3350524#comment-15577964) is not needed anymore. 
### Fix

### Related PRs

### Screenshots
<img width="843" alt="Screenshot 2025-05-30 at 9 07 40 am" src="https://github.com/user-attachments/assets/34e084f3-c179-425a-b8fc-6e048548fed0" />
<img width="1183" alt="Screenshot 2025-05-30 at 9 06 52 am" src="https://github.com/user-attachments/assets/bf655a59-f9c5-490c-b762-3790752aca5f" />


### TODO
