### PR TITLE
[SD-995] Added field check before trying to set the field as null.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -437,7 +437,7 @@
                 "Make max value of page[limit] configurable per entity/bundle - https://www.drupal.org/project/jsonapi_extras/issues/2884292#comment-14794882": "https://www.drupal.org/files/issues/2022-11-21/max_page_limit_configuration-2884292-33.patch"
             },
             "drupal/jsonapi_menu_items": {
-                "Allow filtering of response payload - https://www.drupal.org/project/jsonapi_menu_items/issues/3350524#comment-15577964": "https://www.drupal.org/files/issues/2025-06-02/3350524-filter_fields-7.patch"
+                "Allow filtering of response payload - https://www.drupal.org/project/jsonapi_menu_items/issues/3350524#comment-16132264": "https://www.drupal.org/files/issues/2025-06-03/3350524-filter_fields-8.patch"
             },
             "drupal/linkit": {
                 "Unpublished nodes not included even when option is selected - https://www.drupal.org/project/linkit/issues/3049946#comment-14953079": "https://www.drupal.org/files/issues/2023-03-06/linkit-unpublished-nodes-not-included-3049946-32.patch"

--- a/tide_core.module
+++ b/tide_core.module
@@ -890,5 +890,7 @@ function tide_core_entity_base_field_info_alter(&$fields, EntityTypeInterface $e
  */
 function tide_core_cloned_node_alter(NodeInterface &$node, NodeInterface $original): void {
   // Unsets the value of field_published_date on a cloned entity.
-  $node->set('field_published_date', NULL);
+  if ($node->hasField('field_published_date')) {
+    $node->set('field_published_date', NULL);
+  }
 }


### PR DESCRIPTION
### Jira
https://digital-vic.atlassian.net/browse/SD-995
### Problem/Motivation
During the cloning process, certain fields may not be present on all content types. Attempting to set a value—such as NULL—on a field that doesn't exist causes a fatal error.
### Fix
1. Added a a simple check if node has the field and then set it as null.
### Related PRs

### Screenshots

### TODO
