### PR TITLE
Revert and fix changes related to Drupal 10.4.x upgrade

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -371,9 +371,6 @@
                 "Menu content is not accessible via jsonapi - https://www.drupal.org/node/2915792": "https://www.drupal.org/files/issues/menu_link_content-view-permissions-2915792.patch",
                 "Revisions on relations are not loaded correctly resulting in wrong data in includes - https://www.drupal.org/project/drupal/issues/3088239#comment-15519702": "https://www.drupal.org/files/issues/2024-03-25/3088239-50.patch"
             },
-            "drupal/monitoring": {
-                "Undefined array key addable - https://www.drupal.org/project/monitoring/issues/3528392#comment-16134392": "https://www.drupal.org/files/issues/2025-06-04/undefined-array-key-3528392-1.patch"
-            },
             "drupal/video_embed_field": {
                 "Add support for Ckeditor 5 - https://www.drupal.org/project/video_embed_field/issues/3311063": "./patches/video_embed_field/video_embed_field_6.patch"
             },

--- a/modules/tide_jira/src/Plugin/monitoring/SensorPlugin/TideJiraSensorPlugin.php
+++ b/modules/tide_jira/src/Plugin/monitoring/SensorPlugin/TideJiraSensorPlugin.php
@@ -15,6 +15,7 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
  *
  * @SensorPlugin(
  *   id = "tide_jira",
+ *   addable = false,
  *   label = @Translation("Tide Jira Sensor"),
  *   description = @Translation("Monitors connectivity to the Jira Service Desk API"),
  * )

--- a/modules/tide_ui_restriction/tide_ui_restriction.module
+++ b/modules/tide_ui_restriction/tide_ui_restriction.module
@@ -57,7 +57,6 @@ function tide_ui_restriction_admin_config_access_check_exclude($path) : bool {
     '/admin/config/search',
     '/admin/config/search/path',
     '/admin/config/search/redirect',
-    '/admin/config/people/tfa',
     '/admin/config/content/ckeditor-templates/template-selector/{editor}',
   ];
   if (in_array($path, $paths, TRUE)) {

--- a/src/Plugin/monitoring/SensorPlugin/TideSmtpSensorPlugin.php
+++ b/src/Plugin/monitoring/SensorPlugin/TideSmtpSensorPlugin.php
@@ -11,6 +11,7 @@ use Drupal\monitoring\SensorPlugin\SensorPluginInterface;
  *
  * @SensorPlugin(
  *   id = "tide_smtp_sensor",
+ *   addable = false,
  *   label = @Translation("Tide SMTP Sensor"),
  *   description = @Translation("Monitors connectivity to SMTP"),
  * )

--- a/src/Plugin/monitoring/SensorPlugin/TidetimesSensorPlugin.php
+++ b/src/Plugin/monitoring/SensorPlugin/TidetimesSensorPlugin.php
@@ -11,6 +11,7 @@ use Drupal\monitoring\SensorPlugin\SensorPluginBase;
  *
  * @SensorPlugin(
  *   id = "tide_times_sensor",
+ *   addable = false,
  *   label = @Translation("Tide Times Sensor"),
  *   description = @Translation("Monitors tide modules."),
  * )

--- a/tests/behat/features/text_formats.feature
+++ b/tests/behat/features/text_formats.feature
@@ -5,7 +5,7 @@ Feature: Text formats
 
   @api
   Scenario: Text formats are available
-    Given I am logged in as a user with the "administrator" role
+    Given I am logged in as a user with the "administer filters" permission
     When I go to "admin/config/content/formats"
 
     Then I should see the text "Administrator" in the "Admin Text" row

--- a/tests/behat/features/workflow.feature
+++ b/tests/behat/features/workflow.feature
@@ -5,7 +5,7 @@ Feature: Workflow states and transitions
 
   @api
   Scenario: Workflow states are available
-    Given I am logged in as a user with the administrator role
+    Given I am logged in as a user with the "administer workflows" permission
     When I go to "admin/config/workflow/workflows/manage/editorial"
     Then the "#edit-states-container" element should contain "Draft"
     And the "#edit-states-container" element should contain "Needs Review"


### PR DESCRIPTION
### Problem/Motivation

This PR addresses issues introduced during the initial Drupal 10.4.x upgrade,to ensure consistency between the business logic and the tests.

 It includes,
1. Reverted the tests to their previous state.
2. Removed the patch for `drupal/monitoring`
3. Add required annotation for `@SensorPlugin`
4. removed `'/admin/config/people/tfa',` from `tide_ui_restriction_admin_config_access_check_exclude`
