### PR TITLE
[Release 1.54.0 issues] [SD-1027] Fix relation issue from search_api_exclude_entity

### DIFF
--- a/modules/tide_landing_page/tide_landing_page.install
+++ b/modules/tide_landing_page/tide_landing_page.install
@@ -37,7 +37,7 @@ function tide_landing_page_update_dependencies() {
   $dependencies['tide_landing_page'][10101] = ['tide_core' => 10005];
   $dependencies['tide_landing_page'][10106] = ['tide_core' => 10009];
   $dependencies['tide_landing_page'][10111] = ['tide_core' => 10014];
-
+  $dependencies['tide_landing_page'][10113] = ['tide_core' => 10018];
   return $dependencies;
 }
 
@@ -361,13 +361,13 @@ function tide_landing_page_update_10112() {
  * Add search exclude field.
  */
 function tide_landing_page_update_10113() {
-  $update_service = \Drupal::service('tide_core.entity_update_helper');
-  // Import search exclude fields.
-  $field_configs = [
-    'field.field.node.landing_page.field_search_index_exclude' => 'field_config',
-  ];
-  foreach ($field_configs as $name => $type) {
-    $update_service->import($type, $name);
+  \Drupal::moduleHandler()->loadInclude('tide_core', 'inc', 'includes/helpers');
+  $config_location = [\Drupal::service('extension.list.module')->getPath('tide_landing_page') . '/config/install'];
+  $config_read = _tide_read_config('field.field.node.landing_page.field_search_index_exclude', $config_location, TRUE);
+  $storage = \Drupal::entityTypeManager()->getStorage('field_config');
+  if ($storage->load('node.landing_page.field_search_index_exclude') == NULL) {
+    $config_entity = $storage->createFromStorageRecord($config_read);
+    $config_entity->save();
   }
 
   $form_display = \Drupal::entityTypeManager()

--- a/modules/tide_publication/tide_publication.install
+++ b/modules/tide_publication/tide_publication.install
@@ -57,6 +57,7 @@ function tide_publication_update_dependencies() {
   $dependencies = [];
   $dependencies['tide_publication'][10003] = ['tide_core' => 10005];
   $dependencies['tide_publication'][10008] = ['tide_core' => 10014];
+  $dependencies['tide_publication'][10010] = ['tide_core' => 10018];
   return $dependencies;
 }
 
@@ -299,14 +300,22 @@ function tide_publication_update_10009() {
  * Add search exclude field.
  */
 function tide_publication_update_10010() {
-  $update_service = \Drupal::service('tide_core.entity_update_helper');
   // Import search exclude fields.
   $field_configs = [
     'field.field.node.publication.field_search_index_exclude' => 'field_config',
     'field.field.node.publication_page.field_search_index_exclude' => 'field_config',
   ];
-  foreach ($field_configs as $name => $type) {
-    $update_service->import($type, $name);
+  \Drupal::moduleHandler()->loadInclude('tide_core', 'inc', 'includes/helpers');
+  $config_location = [\Drupal::service('extension.list.module')->getPath('tide_publication') . '/config/install'];
+  // Check if field already exported to config/sync.
+  foreach ($field_configs as $config => $type) {
+    $config_read = _tide_read_config($config, $config_location, TRUE);
+    $storage = \Drupal::entityTypeManager()->getStorage($type);
+    $id = $storage->getIDFromConfigName($config, $storage->getEntityType()->getConfigPrefix());
+    if ($storage->load($id) == NULL) {
+      $config_entity = $storage->createFromStorageRecord($config_read);
+      $config_entity->save();
+    }
   }
 
   $form_display = \Drupal::entityTypeManager()

--- a/modules/tide_search/tide_search.info.yml
+++ b/modules/tide_search/tide_search.info.yml
@@ -4,7 +4,6 @@ type: module
 package: Tide
 core_version_requirement: ^9 || ^10
 dependencies:
-  - search_api:search_api
   - elasticsearch_connector:elasticsearch_connector
   - tide_core:tide_core
   - tide_core:tide_api

--- a/modules/tide_search/tide_search.install
+++ b/modules/tide_search/tide_search.install
@@ -23,6 +23,7 @@ function tide_search_update_dependencies() {
   $dependencies = [];
   $dependencies['tide_search'][10004] = ['tide_core' => 10005];
   $dependencies['tide_search'][10006] = ['tide_core' => 10014];
+  $dependencies['tide_search'][10007] = ['tide_core' => 10018];
   return $dependencies;
 }
 
@@ -214,17 +215,6 @@ function tide_search_update_10006() {
  * Add exclude field to search index.
  */
 function tide_search_update_10007() {
-  if (\Drupal::moduleHandler()->moduleExists('search_api_exclude_entity') === FALSE) {
-    \Drupal::service('module_installer')->install(['search_api_exclude_entity']);
-  }
-  $update_service = \Drupal::service('tide_core.entity_update_helper');
-  // Import search exclude fields.
-  $field_configs = [
-    'field.storage.node.field_search_index_exclude' => 'field_storage_config',
-  ];
-  foreach ($field_configs as $name => $type) {
-    $update_service->import($type, $name);
-  }
   $config = \Drupal::configFactory()->getEditable('search_api.index.node');
   $exclude_entities = [
     'fields' => [
@@ -234,18 +224,4 @@ function tide_search_update_10007() {
   ];
   $config->set('processor_settings.search_api_exclude_entity_processor', $exclude_entities);
   $config->save();
-  // Update site admin role permissions.
-  $config_site = \Drupal::configFactory()->getEditable('user.role.site_admin');
-  $modules = $config_site->get('dependencies.module') ?? [];
-  if (!in_array('search_api_exclude_entity', $modules)) {
-    $modules[] = 'search_api_exclude_entity';
-    $config_site->set('dependencies.module', $modules);
-  }
-  // Add permission if it's not already present.
-  $permissions = $config_site->get('permissions') ?? [];
-  if (!in_array('edit search api exclude entity', $permissions)) {
-    $permissions[] = 'edit search api exclude entity';
-    $config_site->set('permissions', $permissions);
-  }
-  $config_site->save();
 }

--- a/modules/tide_site/tide_site.module
+++ b/modules/tide_site/tide_site.module
@@ -102,6 +102,7 @@ function tide_site_entity_presave(EntityInterface $entity) {
           $fields_helper::FIELD_PRIMARY_SITE,
         ],
         'media' => [$fields_helper::FIELD_SITE],
+        'user' => [$fields_helper::FIELD_SITE],
       ];
       foreach ($map[$entity_type] as $field_name) {
         $field_name = $fields_helper::normaliseFieldName($field_name, $entity_type);

--- a/tide_core.info.yml
+++ b/tide_core.info.yml
@@ -122,6 +122,7 @@ dependencies:
   - entity_browser:entity_browser
   - entity_browser:entity_browser_entity_form
   - create_menus_permission:create_menus_permission
+  - search_api:search_api
   - search_api_exclude_entity:search_api_exclude_entity
 themes:
   - claro

--- a/tide_core.install
+++ b/tide_core.install
@@ -559,3 +559,21 @@ function tide_core_update_10017() {
     ])->save();
   }
 }
+
+/**
+ * Adds search_api_exclude_entity table to node.
+ */
+function tide_core_update_10018() {
+  if (!\Drupal::moduleHandler()->moduleExists('search_api_exclude_entity')) {
+    \Drupal::service('module_installer')->install(['search_api_exclude_entity']);
+  }
+  \Drupal::moduleHandler()->loadInclude('tide_core', 'inc', 'includes/helpers');
+  $config_location = [\Drupal::service('extension.list.module')->getPath('tide_core') . '/config/install'];
+  $config_read = _tide_read_config('field.storage.node.field_search_index_exclude', $config_location, TRUE);
+  $storage = \Drupal::entityTypeManager()->getStorage('field_storage_config');
+  if ($storage->load('node.field_search_index_exclude') == NULL) {
+    $config_entity = $storage->createFromStorageRecord($config_read);
+    $config_entity->save();
+  }
+  Role::load('site_admin')->grantPermission('edit search api exclude entity')->save();
+}


### PR DESCRIPTION
### Jira
https://digital-vic.atlassian.net/browse/SD-1027

### Issues
This PR addresses the issues identified during the release.

### Changes
1.  Move search_api to the tide_core level to fix dependency issues when submodules use it in their logic.
2. Add logics to `hook_update_dependencies` to ensure the update hooks run in a currect order.
3. Update tide_site_entity_presave to handle the user entity form case.