### PR TITLE
Fix TFA route subscriber priority for password reset login

### DIFF
--- a/modules/tide_tfa/src/Routing/TideTfaRouteSubscriber.php
+++ b/modules/tide_tfa/src/Routing/TideTfaRouteSubscriber.php
@@ -4,6 +4,7 @@ namespace Drupal\tide_tfa\Routing;
 
 use Drupal\Core\Routing\RouteSubscriberBase;
 use Symfony\Component\Routing\RouteCollection;
+use Drupal\Core\Routing\RoutingEvents;
 
 /**
  * Listens to the dynamic route events.
@@ -27,4 +28,12 @@ class TideTfaRouteSubscriber extends RouteSubscriberBase {
     }
   }
 
+  /**
+   * Run after TFA route subscriber to ensure our changes take priority.
+   */
+  public static function getSubscribedEvents(): array {
+    return [
+      RoutingEvents::ALTER => ['onAlterRoutes', PHP_INT_MIN - 1],
+    ];
+  }
 }


### PR DESCRIPTION
## Fix TFA route subscriber priority for password reset login

### Issue
Fixes #666 

### Problem
The TFA route subscriber was not properly overriding the `user.reset.login` route because it didn't specify event priority, causing the core TFA module's route subscriber to take precedence.

### Solution
- Added `getSubscribedEvents()` method to `TideTfaRouteSubscriber`
- Set priority to `PHP_INT_MIN - 1` to ensure our route alterations take priority
- Added required import for `RoutingEvents`

### Testing
- Password reset flows now properly use `TideTfaUserController::doResetPassLogin`
- Route override priority is now correctly enforced
- No breaking changes to existing functionality

### Changes
- `modules/tide_tfa/src/Routing/TideTfaRouteSubscriber.php`: Added getSubscribedEvents method with high priority