### PR TITLE
Feature/sd 1055 make default index shard count configurable

### DIFF
--- a/modules/tide_search/config/install/search_api.server.elasticsearch_bay.yml
+++ b/modules/tide_search/config/install/search_api.server.elasticsearch_bay.yml
@@ -22,3 +22,4 @@ backend_config:
   http_method: AUTO
   autocorrect_spell: true
   autocorrect_suggest_words: true
+  number_of_shards: 1

--- a/modules/tide_search/src/ElasticSearch/Parameters/Factory/TideSearchIndexFactory.php
+++ b/modules/tide_search/src/ElasticSearch/Parameters/Factory/TideSearchIndexFactory.php
@@ -29,6 +29,10 @@ class TideSearchIndexFactory extends IndexFactory {
     $filteredIndexName = str_replace('--', '-', $indexName);
     $aliasPrefix = 'search-' . (\Drupal::request()->server->get('SEARCH_HASH') ?: '') . '-';
     $aliasName = $aliasPrefix . str_replace('_', '-', $filteredIndexName) . '-alias';
+    $backend = $index->getServerInstance()->getBackend();
+    $number_of_shards = method_exists($backend, 'getNumberOfShards')
+      ? $backend->getNumberOfShards()
+      : 1;
 
     $indexConfig = [
       'index' => $indexName,
@@ -39,7 +43,7 @@ class TideSearchIndexFactory extends IndexFactory {
           ],
         ],
         'settings' => [
-          'number_of_shards' => $index->getOption('number_of_shards', 5),
+          'number_of_shards' => $number_of_shards,
           'number_of_replicas' => $index->getOption('number_of_replicas', 1),
           'analysis' => [
             "filter" => [

--- a/modules/tide_search/src/Plugin/search_api/backend/TideElasticsearchBackend.php
+++ b/modules/tide_search/src/Plugin/search_api/backend/TideElasticsearchBackend.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace Drupal\tide_search\Plugin\search_api\backend;
+
+use Drupal\elasticsearch_connector\Plugin\search_api\backend\SearchApiElasticsearchBackend;
+use Drupal\Core\Form\FormStateInterface;
+
+/**
+ * @SearchApiBackend(
+ *   id = "elasticsearch",
+ *   label = @Translation("Custom Elasticsearch"),
+ *   description = @Translation("Custom Elasticsearch backend with number_of_shards setting.")
+ * )
+ */
+class TideElasticsearchBackend extends SearchApiElasticsearchBackend {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function defaultConfiguration() {
+    $defaults = parent::defaultConfiguration();
+    $defaults['number_of_shards'] = 1;
+    return $defaults;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function buildConfigurationForm(array $form, FormStateInterface $form_state) {
+    $form = parent::buildConfigurationForm($form, $form_state);
+
+    $form['number_of_shards'] = [
+      '#type' => 'number',
+      '#title' => $this->t('Number of Shards'),
+      '#default_value' => $this->configuration['number_of_shards'],
+      '#min' => 1,
+      '#description' => $this->t('Number of primary shards for the Elasticsearch index.'),
+    ];
+
+    return $form;
+  }
+
+  /**
+   * Get the configured number of shards.
+   *
+   * @return int
+   *   The number of shards for the Elasticsearch index.
+   */
+  public function getNumberOfShards() {
+    return (int) $this->configuration['number_of_shards'];
+  }
+
+}

--- a/modules/tide_search/src/Plugin/search_api/backend/TideElasticsearchBackend.php
+++ b/modules/tide_search/src/Plugin/search_api/backend/TideElasticsearchBackend.php
@@ -2,10 +2,12 @@
 
 namespace Drupal\tide_search\Plugin\search_api\backend;
 
-use Drupal\elasticsearch_connector\Plugin\search_api\backend\SearchApiElasticsearchBackend;
 use Drupal\Core\Form\FormStateInterface;
+use Drupal\elasticsearch_connector\Plugin\search_api\backend\SearchApiElasticsearchBackend;
 
 /**
+ * Custom Elasticsearch Search API Backend definition.
+ *
  * @SearchApiBackend(
  *   id = "elasticsearch",
  *   label = @Translation("Custom Elasticsearch"),

--- a/modules/tide_search/tide_search.install
+++ b/modules/tide_search/tide_search.install
@@ -225,3 +225,14 @@ function tide_search_update_10007() {
   $config->set('processor_settings.search_api_exclude_entity_processor', $exclude_entities);
   $config->save();
 }
+
+/**
+ * Add number_of_shards setting to Elasticsearch Bay config.
+ */
+function tide_search_update_10008() {
+  $config = \Drupal::service('config.factory')->getEditable('search_api.server.elasticsearch_bay');
+  // Only update if the setting is not already set.
+  if ($config->get('number_of_shards') === NULL) {
+    $config->set('number_of_shards', 1)->save();
+  }
+}

--- a/modules/tide_search/tide_search.module
+++ b/modules/tide_search/tide_search.module
@@ -152,3 +152,15 @@ function _tide_search_form_node_form_after_build(array $form, FormStateInterface
 
   return $form;
 }
+
+/**
+ * Implements hook_config_schema_info_alter().
+ */
+function tide_search_config_schema_info_alter(&$schema) {
+  if (isset($schema['plugin.plugin_configuration.search_api_backend.elasticsearch']['mapping'])) {
+    $schema['plugin.plugin_configuration.search_api_backend.elasticsearch']['mapping']['num_of_shards'] = [
+      'type' => 'integer',
+      'label' => 'The number of shards',
+    ];
+  }
+}


### PR DESCRIPTION
### Jira
https://digital-vic.atlassian.net/browse/SD-1055
### Problem/Motivation

### Fix
1. Override the class to add the number of shards in the UI and use that value as default 1. 
2. In the custom create function if the config value is not available set it as 1 by default.
3. This value can be editable easily using the UI and export it in the configs.

### Related PRs

### Screenshots

### TODO
