### PR TITLE
[SDPPE-1] Added patch to allow dashes in index names using elasticsearch_connector

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -447,6 +447,9 @@
             },
             "drupal/tfa_email_otp": {
                 "Disable Verify button on first landing to the tfa form - https://www.drupal.org/project/tfa_email_otp/issues/3469826#comment-15740693": "https://www.drupal.org/files/issues/2024-08-23/3469826-disable-verify-button.patch"
+            },
+            "drupal/elasticsearch_connector": {
+                "Allow dashes in index name": "https://gist.githubusercontent.com/nicksantamaria/95677ffa87a9e1433bfc27c3ebdefd35/raw/68d6eb055150d1e99ad6f0da49d68a6a4c2d6348/elasticsearch_connector-dashed-index.patch"
             }
         },
         "installer-paths": {


### PR DESCRIPTION
https://digital-vic.atlassian.net/browse/SDPPE-1

### Problem/Motivation

Without this patch, we're encountering issues where search API gets 403 errors, because the index prefixes are being mangled by stripping out dash characters (which are present in most lagoon project names).

Without the patch, index operations are going to this
```
POST; /contentvic__pr1875__sapi_media/_bulk`
```
which does not match the index prefix for the RBAC system. So it gets a HTTP 403 response.

Once the dashes are preserved in the elasticsearch_connector config, it hits
```
POST; /content-vic__pr-1875__sapi_media/_bulk
```

Which is OK!

### Fix

Adds patch to include `-` characters in elasticsearch_connector index names.

### Related PRs

- https://github.com/dpc-sdp/sdp-cmdb/pull/1709
- https://github.com/dpc-sdp/ansible-role-sdp-tide-platform/pull/183
- https://github.com/dpc-sdp/ansible-role-sdp-ripple-platform/pull/63
- https://github.com/dpc-sdp/bay/pull/373

### Notes

I am not sure if this is going to be needed once we update to the latest version of elasticsearch_connector - that will need to be decided when that update happens.