### PR TITLE
[SD-1080] increase default date range

### DIFF
--- a/tide_core.module
+++ b/tide_core.module
@@ -904,3 +904,15 @@ function tide_core_field_widget_complete_form_alter(&$field_widget_complete_form
     $field_widget_complete_form['widget'][0]['state']['#default_value'] = 'draft';
   }
 }
+
+/**
+ * Implements hook_element_info_alter().
+ */
+function tide_core_element_info_alter(array &$info) {
+  if (isset($info['date'])) {
+    $info['date']['#date_year_range'] = '1099:2999';
+  }
+  if (isset($info['datetime'])) {
+    $info['datetime']['#date_year_range'] = '1099:2999';
+  }
+}


### PR DESCRIPTION
### Jira

https://digital-vic.atlassian.net/browse/SD-1080

### Problem/Motivation

Users of the schools det content type can not update existing school open dates to a date prior to 1900.

### Fix

This updates the default `min` `max` years for date inputs from `1900:2050` to `1099:2999` which is also completely arbitrary but it will allow users to enter dates before 1900 and after 2050 as well as further into the past and future. The change would effect all date inputs which in this instance seems fine given it just makes the default behiour more practical.

I don't know the reasoning behind this but whenever a date field has a value Drupal will add `min` and `max` attributes to the field. This stops the users from saving a date before 1900 or after 2050 but only client side, this does nothing server side. And as it only takes effect if there is a value this doesn't impact new pages or pages that haven't saved a date before. The default values used as the `min` and `max` years can be seen here: https://github.com/drupal/drupal/blob/11.x/core/lib/Drupal/Core/Datetime/Element/Datetime.php#L68

Let me know if there's a better way to do this, if it's not in the right place, or if you can think of any potential issues.

**Before and After**
<img width="1239" height="272" alt="Screenshot 2025-08-08 at 12 19 39 pm" src="https://github.com/user-attachments/assets/718804ab-614c-4f21-95bc-f7064cb04f21" />

### Related PRs

BE env: https://nginx-php.pr-1899.content-vic.sdp4.sdp.vic.gov.au/node/53432/edit
