### PR TITLE
Fixes a Drupal11 issue before the actual upgrade.

### DIFF
--- a/tide_core.install
+++ b/tide_core.install
@@ -1219,3 +1219,25 @@ function tide_core_update_10031() {
   }
   $approver_role->save();
 }
+
+/**
+ * Drupal 11 introduced the new field, but it causes errors in drush updb,
+ * we need to alter table beforehand to avoid these issues.
+ */
+function tide_core_update_10032(): void {
+  $schema = \Drupal::database()->schema();
+
+  if ($schema->tableExists('router') && !$schema->fieldExists('router', 'alias')) {
+    $spec = [
+      'fields' => [
+        'alias' => [
+          'description' => 'The alias of the route, if applicable.',
+          'type' => 'varchar_ascii',
+          'length' => 255,
+        ],
+      ],
+    ];
+    $schema->addField('router', 'alias', $spec['fields']['alias']);
+    $schema->addIndex('router', 'alias', ['alias'], $spec);
+  }
+}


### PR DESCRIPTION
### Issue
I'm not sure why the Drupal maintainers didn't catch this issue; it's possible their test database is less strict.

```
==> Importing database
 [warning] It is slow to pass large amounts of data via stdin to the sql:cli command. See the Examples at https://www.drush.org/latest/commands/sql_cli/ for an alternative using sql:connect.
 [error]  Drupal\Core\Database\DatabaseExceptionWrapper: SQLSTATE[42S22]: Column not found: 1054 Unknown column 'alias' in 'field list': INSERT INTO "router" ("name", "route", "alias") VALUES (:db_insert_placeholder_0, :db_insert_placeholder_1, :db_insert_placeholder_2), (:db_insert_placeholder_3, :db_insert_placeholder_4, :db_insert_placeholder_5), (:db_insert_placeholder_6, :db_insert_placeholder_7, :db_insert_placeholder_8), (:db_insert_placeholder_9, :db_insert_placeholder_10, :db_insert_placeholder_11); Array
(
    [:db_insert_placeholder_0] => entity.block_content_type.add_form
    [:db_insert_placeholder_1] => O:31:"Symfony\Component\Routing\Alias":2:{s:44:"\Symfony\Component\Routing\Alias\deprecation";a:0:{}s:35:"\Symfony\Component\Routing\Alias\id";s:22:"block_content.type_add";}
    [:db_insert_placeholder_2] => block_content.type_add
    [:db_insert_placeholder_3] => entity.block_content.add_page
    [:db_insert_placeholder_4] => O:31:"Symfony\Component\Routing\Alias":2:{s:44:"\Symfony\Component\Routing\Alias\deprecation";a:0:{}s:35:"\Symfony\Component\Routing\Alias\id";s:22:"block_content.add_page";}
    [:db_insert_placeholder_5] => block_content.add_page
    [:db_insert_placeholder_6] => entity.node.add_page
    [:db_insert_placeholder_7] => O:31:"Symfony\Component\Routing\Alias":2:{s:44:"\Symfony\Component\Routing\Alias\deprecation";a:0:{}s:35:"\Symfony\Component\Routing\Alias\id";s:13:"node.add_page";}
    [:db_insert_placeholder_8] => node.add_page
    [:db_insert_placeholder_9] => entity.node.add_form
    [:db_insert_placeholder_10] => O:31:"Symfony\Component\Routing\Alias":2:{s:44:"\Symfony\Component\Routing\Alias\deprecation";a:0:{}s:35:"\Symfony\Component\Routing\Alias\id";s:8:"node.add";}
    [:db_insert_placeholder_11] => node.add
)
 in Drupal\Core\Routing\MatcherDumper->dump() (line 160 of /app/docroot/core/lib/Drupal/Core/Routing/MatcherDumper.php). 

In ExceptionHandler.php line 96:
                                                                               
  SQLSTATE[42S22]: Column not found: 1054 Unknown column 'alias' in 'field li  
  st': INSERT INTO "router" ("name", "route", "alias") VALUES (:db_insert_pla  
  ceholder_0, :db_insert_placeholder_1, :db_insert_placeholder_2), (:db_inser  
  t_placeholder_3, :db_insert_placeholder_4, :db_insert_placeholder_5), (:db_  
  insert_placeholder_6, :db_insert_placeholder_7, :db_insert_placeholder_8),   
  (:db_insert_placeholder_9, :db_insert_placeholder_10, :db_insert_placeholde  
  r_11); Array                                                                 
  (                                                                            
      [:db_insert_placeholder_0] => entity.block_content_type.add_form         
      [:db_insert_placeholder_1] => O:31:"Symfony\Component\Routing\Alias":2:  
  {s:44:"\Symfony\Component\Routing\Alias\deprecation";a:0:{}s:35:"\Symfony\C  
  omponent\Routing\Alias\id";s:22:"block_content.type_add";}                   
      [:db_insert_placeholder_2] => block_content.type_add                     
      [:db_insert_placeholder_3] => entity.block_content.add_page              
      [:db_insert_placeholder_4] => O:31:"Symfony\Component\Routing\Alias":2:  
  {s:44:"\Symfony\Component\Routing\Alias\deprecation";a:0:{}s:35:"\Symfony\C  
  omponent\Routing\Alias\id";s:22:"block_content.add_page";}                   
      [:db_insert_placeholder_5] => block_content.add_page                     
      [:db_insert_placeholder_6] => entity.node.add_page                       
      [:db_insert_placeholder_7] => O:31:"Symfony\Component\Routing\Alias":2:  
  {s:44:"\Symfony\Component\Routing\Alias\deprecation";a:0:{}s:35:"\Symfony\C  
  omponent\Routing\Alias\id";s:13:"node.add_page";}                            
      [:db_insert_placeholder_8] => node.add_page                              
      [:db_insert_placeholder_9] => entity.node.add_form                       
      [:db_insert_placeholder_10] => O:31:"Symfony\Component\Routing\Alias":2  
  :{s:44:"Symfony\Component\Routing\Aliasdeprecation";a:0:{}s:35:"Symfony\\\\  
  Component\Routing\Alias\id";s:8:"node.add";}                                 
      [:db_insert_placeholder_11] => node.add                                  
  )                                                                            
                                                                               

In PdoTrait.php line 109:
                                                                               
  SQLSTATE[42S22]: Column not found: 1054 Unknown column 'alias' in 'field li  
  st'        
  ```