### PR TITLE
[SD-1673] Add the missed package.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,6 +21,7 @@
         "drupal/monitoring": "^1.13",
         "drupal/ckeditor_templates": "dev-feature/d10-compatible-with-ck5-support",
         "drupal/ctools": "^3.14",
+        "drupal/js_cookie": "^1.0",
         "drupal/diff": "^1.1",
         "drupal/editor_advanced_link": "2.3.1",
         "drupal/entity_browser": "^2.9",


### PR DESCRIPTION
### Jira
https://digital-vic.atlassian.net/browse/SD-1673

### changes
- https://www.drupal.org/project/autologout/issues/3557620
- I don't know why these maintainers are so mean, they just removed the package without any update hooks.
- We're keeping it for now, but we plan to disable the `js_cookie` module in the next release and remove it entirely in the one after that.