### PR TITLE
[SD-1677] Assign permissions for CKEditor template usage.

### DIFF
--- a/src/TideCoreOperation.php
+++ b/src/TideCoreOperation.php
@@ -285,4 +285,15 @@ class TideCoreOperation {
     }
   }
 
+  /**
+   * Assign permissions for CKEditor template usage.
+   */
+  public function assignCkeditorTemplatesPermission() {
+    $role = Role::load('authenticated');
+    if ($role) {
+      $role->grantPermission('insert ckeditor templates');
+      $role->save();
+    }
+  }
+
 }

--- a/tide_core.install
+++ b/tide_core.install
@@ -65,6 +65,9 @@ function tide_core_install() {
 
   // Enables paragraphs_library.
   $tideCoreOperation->alterParagraphsLibrary();
+
+  // Assign permissions for CKEditor template usage.
+  $tideCoreOperation->assignCkeditorTemplatesPermission();
 }
 
 /**
@@ -1370,4 +1373,12 @@ function tide_core_update_10036() {
     }
     $config->save(TRUE);
   }
+}
+
+/**
+ * Assign permissions for CKEditor template usage.
+ */
+function tide_core_update_10037() {
+  $tideCoreOperation = new TideCoreOperation();
+  $tideCoreOperation->assignCkeditorTemplatesPermission();
 }


### PR DESCRIPTION
### Change
The `insert ckeditor templates` permission was newly added by the upstream module to control who can insert actual CKEditor templates. Since all users could perform this action in previous versions, we have assigned this permission to all `authenticated` users to maintain alignment with the previous logic.