### PR TITLE
[SD-1641] [SD-1662] Fix 'Publication infomation' typo in group_publication_metadata label and Previewer role shouldn't be able to bypass site restriction

### DIFF
--- a/modules/tide_publication/tide_publication.install
+++ b/modules/tide_publication/tide_publication.install
@@ -496,3 +496,18 @@ function tide_publication_update_10012() {
   }
   $entity_form_display->save();
 }
+
+/**
+ * Fix 'Publication infomation' typo in group_publication_metadata label.
+ */
+function tide_publication_update_10013() {
+  /** @var \Drupal\Core\Entity\Display\EntityFormDisplayInterface $entity_form_display */
+  $entity_form_display = \Drupal::entityTypeManager()->getStorage('entity_form_display')->load('node.publication.default');
+  $field_group = $entity_form_display->getThirdPartySettings('field_group');
+
+  if (isset($field_group['group_publication_metadata']) && $field_group['group_publication_metadata']['label'] === 'Publication infomation') {
+    $field_group['group_publication_metadata']['label'] = 'Publication information';
+    $entity_form_display->setThirdPartySetting('field_group', 'group_publication_metadata', $field_group['group_publication_metadata']);
+    $entity_form_display->save();
+  }
+}

--- a/tide_core.install
+++ b/tide_core.install
@@ -1382,3 +1382,14 @@ function tide_core_update_10037() {
   $tideCoreOperation = new TideCoreOperation();
   $tideCoreOperation->assignCkeditorTemplatesPermission();
 }
+
+/**
+ * Revoke 'bypass site restriction' permission from previewer role.
+ */
+function tide_core_update_10038() {
+  $role = Role::load('previewer');
+  if ($role && $role->hasPermission('bypass site restriction')) {
+    $role->revokePermission('bypass site restriction');
+    $role->save();
+  }
+}


### PR DESCRIPTION
### Jira
https://digital-vic.atlassian.net/browse/SD-1641
https://digital-vic.atlassian.net/browse/SD-1662

### Changes
1. Fixes a typo.
2. Previewer role shouldn't be able to bypass site restriction