### PR TITLE
[SD-1598] Updated AuthorByRoleFilter to improve the slow query performance.

### DIFF
--- a/src/Plugin/views/filter/AuthorByRoleFilter.php
+++ b/src/Plugin/views/filter/AuthorByRoleFilter.php
@@ -121,25 +121,29 @@ class AuthorByRoleFilter extends InOperator {
     }
 
     $this->valueOptions = [];
-    // Anonymous user will display always.
-    $this->valueOptions[User::getAnonymousUser()->id()] = User::getAnonymousUser()->getDisplayName();
+    $this->valueOptions[0] = $this->t('Anonymous');
+
     $roles = array_filter($this->options['roles'] ?? []);
 
-    $query = $this->userStorage->getQuery()
-      ->accessCheck(FALSE)
-      ->sort('name');
+    // Use a direct database query.
+    $db = \Drupal::database();
+    $query = $db->select('users_field_data', 'u');
+    $query->fields('u', ['uid', 'name']);
+    $query->condition('u.status', 1);
+    $query->condition('u.uid', 0, '>');
+    $query->orderBy('u.name', 'ASC');
 
+    // If roles are filtered.
+    // Join the user__roles table.
     if (!empty($roles)) {
-      $query->condition('roles', array_values($roles), 'IN');
+      $query->join('user__roles', 'ur', 'ur.entity_id = u.uid');
+      $query->condition('ur.roles_target_id', array_values($roles), 'IN');
     }
 
-    $uids = $query->execute();
+    $results = $query->execute()->fetchAllKeyed();
 
-    if ($uids) {
-      $users = $this->userStorage->loadMultiple($uids);
-      foreach ($users as $user) {
-        $this->valueOptions[$user->id()] = $user->getDisplayName();
-      }
+    foreach ($results as $uid => $name) {
+      $this->valueOptions[$uid] = $name;
     }
 
     return $this->valueOptions;

--- a/src/Plugin/views/filter/AuthorByRoleFilter.php
+++ b/src/Plugin/views/filter/AuthorByRoleFilter.php
@@ -4,7 +4,6 @@ namespace Drupal\tide_core\Plugin\views\filter;
 
 use Drupal\Core\Entity\EntityStorageInterface;
 use Drupal\Core\Form\FormStateInterface;
-use Drupal\user\Entity\User;
 use Drupal\user\RoleInterface;
 use Drupal\views\Plugin\views\filter\InOperator;
 use Symfony\Component\DependencyInjection\ContainerInterface;


### PR DESCRIPTION
<!--
Please follow these rules:
1. SUBJECT: use format [SUPSSP-123] Verb in past tense with dot at the end.
   - This subject will be used as a commit message after PR is merged.
   - Verbs are usually one of these: Updated, Refactored, Removed, Changed, Added.
   - If there is no ticket - do not put [NOTICKET].

2. BODY: fill-in the template below

3. LABEL: Assign 'Needs review' label as soon as you ready to have this reviewed.

4. ASSIGNEE: Assign at least 2 reviewers.     

5. SLACK: Post a link to this PR to #developers channel.

No need to remove these lines - they are comments.
-->

**JIRA issue:** https://digital-vic.atlassian.net/browse/SD-1706

### ISSUE
Through New Relic analysis, two primary bottlenecks were identified:

N+1 Breadcrumb Computation (56% of load): The tide_breadcrumbs logic was triggering recursive tree searches for every node in the administration list, even though breadcrumbs are not displayed there. (Fixed in the tide_breadcrumb branch)

User Entity Bloat in Filters (6.4s delay): The custom "Author by Role" filter was performing a loadMultiple() on all users matching specific roles. This triggered heavy hooks (e.g., user_expire) and massive memory consumption just to populate a dropdown list.
<img width="1242" height="745" alt="Screenshot 2026-04-13 at 1 07 13 pm" src="https://github.com/user-attachments/assets/3c822e9b-75f7-4f36-9679-fd9b1bc80947" />


### Changed

1. Replaced the Entity API loadMultiple() calls with a direct db_select query. This avoids the overhead of initialising hundreds of User objects and triggering hook_user_load for every user in the system.

2. Anonymous User Handling: Switched from a full User::getAnonymousUser() entity load to a static translated string for the "Anonymous" label.

### Screenshots

<!--
Provide as many screenshots as required to make reviewers understand what was changed.
-->