### PR TITLE
[SD-1646] Applied Select2 widget to Site filters

### DIFF
--- a/modules/tide_site/tide_site.install
+++ b/modules/tide_site/tide_site.install
@@ -237,3 +237,21 @@ function tide_site_update_10006() {
   $config->set($fields_path, $fields);
   $config->save(TRUE);
 }
+
+/**
+ * Change site option to multiple select for moderated content filters.
+ */
+function tide_site_update_10007() {
+  $view_ids = [
+    'views.view.tide_site_moderated_content_filters',
+    'views.view.summary_contents_filters',
+  ];
+  foreach ($view_ids as $view_id) {
+    $config = \Drupal::configFactory()->getEditable($view_id);
+    $key = 'display.default.display_options.filters.field_node_site_target_id.expose.multiple';
+    if ($config->get($key) === FALSE) {
+      $config->set($key, TRUE);
+      $config->save(TRUE);
+    }
+  }
+}

--- a/modules/tide_site/tide_site.module
+++ b/modules/tide_site/tide_site.module
@@ -749,6 +749,30 @@ function tide_site_tide_api_jsonapi_custom_query_parameters_alter(&$custom_param
  * Implements hook_form_FORM_ID_alter().
  */
 function tide_site_form_views_exposed_form_alter(&$form, FormStateInterface $form_state, $form_id) {
+  // Apply Select2 widget to Site exposed filters on the Content and
+  // Moderated content admin views. Visual only — works for both single and
+  // multi-value selects; whether it's multi is decided by the view config.
+  // Lists both possible filter keys so it works in either deployment
+  // (with or without tide_site_restriction, which swaps the filter name).
+  $select2_form_filters = [
+    'views-exposed-form-summary-contents-filters-page-1' => ['field_node_site_target_id', 'sub_sites_filter'],
+    'views-exposed-form-tide-site-moderated-content-filters-moderated-content' => ['field_node_site_target_id'],
+  ];
+  if (!empty($form['#id']) && isset($select2_form_filters[$form['#id']])) {
+    foreach ($select2_form_filters[$form['#id']] as $filter) {
+      if (!empty($form[$filter])) {
+        $form[$filter]['#type'] = 'select2';
+        $form[$filter]['#select2'] = [
+          'allowClear' => TRUE,
+          'dropdownAutoWidth' => FALSE,
+          'width' => 'resolve',
+          'closeOnSelect' => FALSE,
+          'placeholder' => t('- Any -'),
+        ];
+      }
+    }
+  }
+
   $view = $form_state->get('view');
   if ($view && $view instanceof ViewExecutable) {
     if ($view->id() === 'summary_contents' && $view->current_display === 'page') {

--- a/modules/tide_site_restriction/tide_site_restriction.module
+++ b/modules/tide_site_restriction/tide_site_restriction.module
@@ -125,20 +125,18 @@ function tide_site_restriction_views_pre_view(ViewExecutable $view, $display_id,
     $site_restriction_helper = \Drupal::service('tide_site_restriction.helper');
     $user_can_bypass_restriction = $site_restriction_helper->canBypassRestriction($account);
 
+    // Visual (multi-value + Select2) is handled by tide_site. Here we only
+    // inject the user's allowed sites as the default exposed input so the
+    // view is restricted on first load.
     $filters = $view->display_handler->getOption('filters');
-    if (!empty($filters[$filter])) {
-      $filters[$filter]['expose']['multiple'] = TRUE;
-      $view->display_handler->setOption('filters', $filters);
-
-      if (!$user_can_bypass_restriction) {
-        /** @var \Drupal\user\Entity\User $user */
-        $user = User::load($account->id());
-        $user_sites = $site_restriction_helper->getUserSites($user);
-        $exposed_input = $view->getExposedInput();
-        if (!empty($user_sites) && empty($exposed_input)) {
-          $exposed_input[$filter] = $user_sites;
-          $view->setExposedInput($exposed_input);
-        }
+    if (!empty($filters[$filter]) && !$user_can_bypass_restriction) {
+      /** @var \Drupal\user\Entity\User $user */
+      $user = User::load($account->id());
+      $user_sites = $site_restriction_helper->getUserSites($user);
+      $exposed_input = $view->getExposedInput();
+      if (!empty($user_sites) && empty($exposed_input)) {
+        $exposed_input[$filter] = $user_sites;
+        $view->setExposedInput($exposed_input);
       }
     }
   }
@@ -229,12 +227,12 @@ function tide_site_restriction_views_pre_view(ViewExecutable $view, $display_id,
  * Implements hook_form_FORM_ID_alter().
  */
 function tide_site_restriction_form_views_exposed_form_alter(&$form, FormStateInterface $form_state, $form_id) {
-  // Enable Select2 to Site filter of Content Admin view.
+  // Enable Select2 on Site filters for the views this module owns.
+  // summary_contents_filters and tide_site_moderated_content_filters are
+  // styled by tide_site instead, so they're intentionally omitted here.
   $form_ids = [
     'views-exposed-form-media-media-page-list' => 'field_media_site_target_id',
-    'views-exposed-form-summary-contents-filters-page-1' => 'sub_sites_filter',
     'views-exposed-form-user-admin-people-page-1' => 'field_user_site_target_id_1',
-    'views-exposed-form-tide-site-moderated-content-filters-moderated-content' => 'field_node_site_target_id',
   ];
   foreach ($form_ids as $form_id => $filter) {
     if (!empty($form['#id']) && $form['#id'] == $form_id) {


### PR DESCRIPTION
### Jira
https://digital-vic.atlassian.net/browse/SD-1646

### Change
1. Move `Select2` styling for the `Content` and `Moderated content` admin views into `tide_site` so the widget is applied regardless of whether `tide_site_restriction` is enabled.
2. `tide_site_restriction` now only injects the user's allowed sites as default exposed input and no longer toggles the filter to multi-value or re-applies `Select2` for these views.