### PR TITLE
[SD-1801] Fixes an incompatibility issue: tide_api include resolver broken by jsonapi_resources >= 1.6

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -466,6 +466,9 @@
             },
             "drupal/views_bulk_operations": {
                 "getSubscribedEvents() fails on `drush updb` due to autoloader negative-cache (missing class_exists() guard) - https://www.drupal.org/project/views_bulk_operations/issues/3589629#comment-16583537": "https://www.drupal.org/files/issues/2026-05-12/views_bulk_operations-class-exists-guard-3589629-2.patch"
+            },
+            "drupal/jsonapi_resources": {
+                "ResourceObjectNormalizer should declare a decoration_priority to stay innermost - https://git.drupalcode.org/project/jsonapi_resources/-/work_items/3599418": "https://git.drupalcode.org/project/jsonapi_resources/-/merge_requests/39.patch"
             }
           },
         "installer-paths": {

--- a/modules/tide_api/src/TideApiIncludeResolver.php
+++ b/modules/tide_api/src/TideApiIncludeResolver.php
@@ -35,7 +35,7 @@ class TideApiIncludeResolver extends IncludeResolver {
     assert($data instanceof ResourceObject || $data instanceof ResourceObjectData);
     $data = $data instanceof ResourceObjectData ? $data : new ResourceObjectData([$data], 1);
     $include_tree = self::toIncludeTree($data, $include_parameter);
-    return IncludedData::deduplicate($this->resolveIncludeTree($include_tree, $data));
+    return IncludedData::deduplicate($this->innerService->resolveIncludeTree($include_tree, $data));
   }
 
   /**

--- a/modules/tide_api/tide_api.services.yml
+++ b/modules/tide_api/tide_api.services.yml
@@ -34,7 +34,7 @@ services:
     class: Drupal\tide_api\TideApiIncludeResolver
     decorates: jsonapi.include_resolver
     public: false
-    decoration_priority: 5
+    decoration_priority: -10
     arguments:
       - '@tide_api.include_resolver.inner'
       - '@entity_type.manager'


### PR DESCRIPTION
### Jira
https://digital-vic.atlassian.net/browse/SD-1801

### Issues
1. jsonapi_resources 1.6 added a decorator on the jsonapi.include_resolver service. Because tide_api.include_resolver used decoration_priority: 5, the jsonapi_resources decorator ended up as the outermost layer, so requests no longer entered TideApiIncludeResolver::resolve().

This bypassed Tide's lenient include-path handling: include paths that don't exist on every bundle (e.g. a frontend fallback like field_site_footer_logos.field_feature_image) now hit Drupal core's strict validation and return HTTP 400 instead of being silently ignored. This breaks previously-working JSON:API requests from Ripple.

2. [ResourceObjectNormalizer should declare a decoration_priority to stay innermost (silently disables jsonapi_extras enhancers)](https://git.drupalcode.org/project/jsonapi_resources/-/work_items/3599418)

