### PR TITLE
[SD-1806] Upgrade field_group to ^4.0.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
         "drupal/entity_embed": "1.7",
         "drupal/environment_indicator": "^4.0",
         "drupal/fast_404": "^3.0",
-        "drupal/field_group": "^3.6",
+        "drupal/field_group": "^4.0.0",
         "drupal/google_analytics": "^4.0",
         "drupal/hotjar": "^3.1",
         "drupal/linkit": "^7.0",
@@ -383,10 +383,6 @@
             },
             "drupal/token": {
                 "Summary token not fully handled in fields - https://www.drupal.org/project/token/issues/2924873#comment-15704936": "https://www.drupal.org/files/issues/2024-07-30/tokens_body_with_summary-2924873-18.patch"
-            },
-            "drupal/field_group": {
-                "Nested groups render on other entity forms (or when fields are inaccessible) when they shouldn't: https://www.drupal.org/project/field_group/issues/3098550#comment-15712652": "https://www.drupal.org/files/issues/2024-08-05/3098550-19.patch",
-                "Tabs with invalid input are not focused - https://www.drupal.org/project/field_group/issues/2894351#comment-15712685": "https://www.drupal.org/files/issues/2024-08-05/2894351-32.patch"
             },
             "drupal/jira_rest": {
                 "Automated Drupal 10 compatibility fixes - https://www.drupal.org/project/jira_rest/issues/3288088#comment-14567776": "https://www.drupal.org/files/issues/2022-06-16/jira_rest.4.x-dev.rector.patch"


### PR DESCRIPTION
### Issue
The node form display cannot be edited
```
    at HTMLTableRowElement.<anonymous> (js_gmjfN5AmA5R6b_JLetdsa4jS9vg0Mvxcre1hjEEIFQo.js?scope=footer&delta=0&language=en&theme=claro&include=eJx1kWFyxCAIhS9kkjP0JA5RTNkaSBEz3dvXTGp22t3-Er83j3kAxJXYm0ieQaefdzRFHN9lRyU2ZHNQTbIsUm2KWjfI44O4kEGlc4Z9MJiLC5ISYsfnr0G9EASjHYdM_PGLN3fGqLA8U8WyCZdmO7UjnXJTb58V9T4m0dUh76TCa8vtiSMFMNHe5qX4jyXBTkHYJcIc_aJSt-msK7le9MaXULAUEvaKbbMRdVolQh6OaG3WWUHvrpChhzbPtc4H8XCDL_f3IlgCbPh2XOsbFJ2qhQ:301:1369)
```

