### PR TITLE
Remove jsonapi_resources as it’s been fixed

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -462,9 +462,6 @@
             },
             "drupal/views_bulk_operations": {
                 "getSubscribedEvents() fails on `drush updb` due to autoloader negative-cache (missing class_exists() guard) - https://www.drupal.org/project/views_bulk_operations/issues/3589629#comment-16583537": "https://www.drupal.org/files/issues/2026-05-12/views_bulk_operations-class-exists-guard-3589629-2.patch"
-            },
-            "drupal/jsonapi_resources": {
-                "ResourceObjectNormalizer should declare a decoration_priority to stay innermost - https://git.drupalcode.org/project/jsonapi_resources/-/work_items/3599418": "https://git.drupalcode.org/project/jsonapi_resources/-/commit/5b6760c85e918d68780acb8c472420b350b78b17.patch"
             }
           },
         "installer-paths": {


### PR DESCRIPTION
The issue has been resolved. https://git.drupalcode.org/project/jsonapi_resources/-/merge_requests/39#note_1255821