### PR TITLE
Set enable_site_coupling default to FALSE

### DIFF
--- a/modules/tide_site_restriction/src/Plugin/Field/FieldWidget/TideSiteRestrictionFieldWidget.php
+++ b/modules/tide_site_restriction/src/Plugin/Field/FieldWidget/TideSiteRestrictionFieldWidget.php
@@ -94,7 +94,7 @@ class TideSiteRestrictionFieldWidget extends OptionsButtonsWidget implements Con
    */
   public static function defaultSettings() {
     return [
-      'enable_site_coupling' => TRUE,
+      'enable_site_coupling' => FALSE,
     ] + parent::defaultSettings();
   }
 


### PR DESCRIPTION
Set `enable_site_coupling` default to `FALSE` in TideSiteRestrictionFieldWidget.php, as only content-vic and howqua require the feature:
- https://github.com/dpc-sdp/tide_core/pull/781