### PR TITLE
[SD-1700] Added schema.org module

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -94,6 +94,7 @@
         "drupal/site_alert": "^1.3",
         "drupal/migrate_source_ui": "^1.0",
         "drupal/migrate_file": "^2.0",
+        "drupal/schema_metatag": "^3.0",
         "drupal/select2": "^1.7",
         "oomphinc/composer-installers-extender": "^2.0",
         "select2/select2": "4.0.*",

--- a/config/install/core.entity_form_display.taxonomy_term.sites.default.yml
+++ b/config/install/core.entity_form_display.taxonomy_term.sites.default.yml
@@ -6,6 +6,7 @@ dependencies:
     - field.field.taxonomy_term.sites.field_acknowledgement_to_country
     - field.field.taxonomy_term.sites.field_additional_comment
     - field.field.taxonomy_term.sites.field_bottom_corner_graphic
+    - field.field.taxonomy_term.sites.field_enable_breadcrumbs
     - field.field.taxonomy_term.sites.field_notes
     - field.field.taxonomy_term.sites.field_print_friendly_logo
     - field.field.taxonomy_term.sites.field_prominence_ack_to_country
@@ -165,6 +166,13 @@ content:
     settings:
       progress_indicator: throbber
       preview_image_style: thumbnail
+    third_party_settings: {  }
+  field_enable_breadcrumbs:
+    type: boolean_checkbox
+    weight: 28
+    region: content
+    settings:
+      display_label: true
     third_party_settings: {  }
   field_notes:
     type: string_textarea

--- a/config/install/field.field.taxonomy_term.sites.field_enable_breadcrumbs.yml
+++ b/config/install/field.field.taxonomy_term.sites.field_enable_breadcrumbs.yml
@@ -9,7 +9,7 @@ field_name: field_enable_breadcrumbs
 entity_type: taxonomy_term
 bundle: sites
 label: 'Enable breadcrumbs for JSON_LD(schema.org)'
-description: ''
+description: 'Turn on schema breadcrumbs for website.'
 required: false
 translatable: false
 default_value:

--- a/config/install/field.field.taxonomy_term.sites.field_enable_breadcrumbs.yml
+++ b/config/install/field.field.taxonomy_term.sites.field_enable_breadcrumbs.yml
@@ -1,0 +1,22 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.taxonomy_term.field_enable_breadcrumbs
+    - taxonomy.vocabulary.sites
+id: taxonomy_term.sites.field_enable_breadcrumbs
+field_name: field_enable_breadcrumbs
+entity_type: taxonomy_term
+bundle: sites
+label: 'Enable breadcrumbs for JSON_LD(schema.org)'
+description: ''
+required: false
+translatable: false
+default_value:
+  -
+    value: 0
+default_value_callback: ''
+settings:
+  on_label: 'On'
+  off_label: 'Off'
+field_type: boolean

--- a/config/install/field.storage.taxonomy_term.field_enable_breadcrumbs.yml
+++ b/config/install/field.storage.taxonomy_term.field_enable_breadcrumbs.yml
@@ -1,0 +1,17 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - taxonomy
+id: taxonomy_term.field_enable_breadcrumbs
+field_name: field_enable_breadcrumbs
+entity_type: taxonomy_term
+type: boolean
+settings: {  }
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/optional/metatag.metatag_defaults.node.yml
+++ b/config/optional/metatag.metatag_defaults.node.yml
@@ -9,3 +9,5 @@ tags:
   canonical_url: '[node:url]'
   og_image: '[node:field_featured_image:entity:field_media_image:entity:url]'
   og_locale: 'en-AU'
+  schema_web_page_type: WebPage
+  schema_web_page_breadcrumb: 'Yes'

--- a/modules/tide_breadcrumbs/tide_breadcrumbs.module
+++ b/modules/tide_breadcrumbs/tide_breadcrumbs.module
@@ -176,3 +176,31 @@ function tide_breadcrumbs_node_storage_load(array $entities) {
     $is_processing = FALSE;
   }
 }
+
+/**
+ * Implements hook_tide_breadcrumb_alter().
+ *
+ * Overrides tide_core's baseline menu breadcrumb with the chained
+ * Primary/Section-site trail computed by tide_breadcrumbs, so the JSON-LD
+ * BreadcrumbList reflects the richer taxonomy-aware hierarchy whenever this
+ * module is enabled. URL normalisation (front-end host, https, /site-XXXX
+ * stripping) is still applied downstream by tide_core.
+ *
+ * @see \Drupal\tide_core\TideBreadcrumb::build()
+ * @see \Drupal\tide_breadcrumbs\TideBreadcrumbBuilder::buildFullTrail()
+ */
+function tide_breadcrumbs_tide_breadcrumb_alter(array &$trail, NodeInterface $node, array $context) {
+  /** @var \Drupal\tide_breadcrumbs\TideBreadcrumbBuilder $builder */
+  $builder = \Drupal::service('tide_breadcrumbs.breadcrumb_builder');
+  $custom = $builder->buildFullTrail($node);
+  if (empty($custom)) {
+    return;
+  }
+
+  // Keep "Home" pointing at the site root, consistent with tide_core.
+  if (($custom[0]['title'] ?? '') === 'Home') {
+    $custom[0]['url'] = '/';
+  }
+
+  $trail = $custom;
+}

--- a/modules/tide_news/config/install/metatag.metatag_defaults.node__news.yml
+++ b/modules/tide_news/config/install/metatag.metatag_defaults.node__news.yml
@@ -1,0 +1,15 @@
+langcode: en
+status: true
+dependencies: {  }
+id: node__news
+label: 'Content: News'
+tags:
+  schema_article_date_modified: '[node:changed:html_datetime]'
+  schema_article_date_published: '[node:field_news_date:date:html_datetime]'
+  schema_article_description: '[node:field_news_intro_text]'
+  schema_article_headline: '[node:title]'
+  schema_article_id: '[node:url:fe_url]'
+  schema_article_image: 'a:2:{s:5:"@type";s:11:"ImageObject";s:3:"url";s:63:"[node:field_featured_image:entity:field_media_image:entity:url]";}'
+  schema_article_main_entity_of_page: '[node:url:fe_url]'
+  schema_article_publisher: 'a:2:{s:5:"@type";s:12:"Organization";s:4:"name";s:40:"[node:field_node_department:entity:name]";}'
+  schema_article_type: NewsArticle

--- a/modules/tide_news/config/install/metatag.metatag_defaults.node__news.yml
+++ b/modules/tide_news/config/install/metatag.metatag_defaults.node__news.yml
@@ -13,3 +13,4 @@ tags:
   schema_article_main_entity_of_page: '[node:url:fe_url]'
   schema_article_publisher: 'a:2:{s:5:"@type";s:12:"Organization";s:4:"name";s:40:"[node:field_node_department:entity:name]";}'
   schema_article_type: NewsArticle
+  schema_web_page_publisher: 'a:2:{s:5:"@type";s:12:"Organization";s:4:"name";s:40:"[node:field_node_department:entity:name]";}'

--- a/modules/tide_news/tide_news.info.yml
+++ b/modules/tide_news/tide_news.info.yml
@@ -18,6 +18,9 @@ dependencies:
   - maxlength:maxlength
   - metatag:metatag
   - metatag:metatag_open_graph
+  - schema_metatag:schema_metatag
+  - schema_metatag:schema_article
+  - schema_metatag:schema_organization
   - paragraphs:paragraphs
   - select2:select2
   - smart_trim:smart_trim
@@ -45,6 +48,7 @@ config_devel:
     - field.field.node.news.field_topic
     - field.storage.node.field_news_date
     - field.storage.news.field_news_intro_text
+    - metatag.metatag_defaults.node__news
   optional:
     - field.field.node.news.field_show_content_rating
     - jsonapi_extras.jsonapi_resource_config.node--news

--- a/modules/tide_news/tide_news.install
+++ b/modules/tide_news/tide_news.install
@@ -213,3 +213,21 @@ function tide_news_update_10004() {
     $entity_form_display->save();
   }
 }
+
+/**
+ * Import the News schema (schema_article) defaults for existing sites.
+ */
+function tide_news_update_10005() {
+  \Drupal::service('module_installer')->install(['schema_metatag', 'schema_article', 'schema_organization']);
+
+  \Drupal::moduleHandler()->loadInclude('tide_core', 'inc', 'includes/helpers');
+  $config_name = 'metatag.metatag_defaults.node__news';
+  $config_location = [\Drupal::service('extension.list.module')->getPath('tide_news') . '/config/install'];
+  $config_read = _tide_read_config($config_name, $config_location, TRUE);
+  $storage = \Drupal::entityTypeManager()->getStorage('metatag_defaults');
+  $id = $storage->getIDFromConfigName($config_name, $storage->getEntityType()->getConfigPrefix());
+  if ($storage->load($id) === NULL) {
+    $config_entity = $storage->createFromStorageRecord($config_read);
+    $config_entity->save();
+  }
+}

--- a/modules/tide_news/tide_news.install
+++ b/modules/tide_news/tide_news.install
@@ -231,3 +231,20 @@ function tide_news_update_10005() {
     $config_entity->save();
   }
 }
+
+/**
+ * Add the WebPage publisher (owner = department) to the News schema defaults.
+ */
+function tide_news_update_10006() {
+  /** @var \Drupal\metatag\Entity\MetatagDefaults|null $defaults */
+  $defaults = \Drupal::entityTypeManager()->getStorage('metatag_defaults')->load('node__news');
+  if ($defaults === NULL) {
+    return;
+  }
+  $tags = $defaults->get('tags') ?: [];
+  if (!isset($tags['schema_web_page_publisher'])) {
+    $tags['schema_web_page_publisher'] = 'a:2:{s:5:"@type";s:12:"Organization";s:4:"name";s:40:"[node:field_node_department:entity:name]";}';
+    $defaults->set('tags', $tags);
+    $defaults->save();
+  }
+}

--- a/modules/tide_site/tests/behat/features/schema_breadcrumb.feature
+++ b/modules/tide_site/tests/behat/features/schema_breadcrumb.feature
@@ -5,10 +5,14 @@ Feature: JSON-LD breadcrumb (tide_core)
   Schema.org BreadcrumbList, gated per site, so that structured data reflects
   the site's information architecture.
 
-  The breadcrumb engine lives in tide_core: it builds the trail from the node's
-  primary-site main menu (starting at the site root "Home"), is switched on/off
-  per site via the "Enable breadcrumbs" field, and is exposed through the node's
-  computed json_ld field.
+  The breadcrumb engine lives in tide_core: it builds the trail from the main
+  menu of the site being viewed (starting at the site root "Home"), is switched
+  on/off per site via the "Enable breadcrumbs" field, and is exposed through the
+  node's computed json_ld field.
+
+  This feature lives under tide_site (not tide_core) because the scenarios set
+  field_node_primary_site / field_node_site on nodes, and those field instances
+  are only provisioned onto content types when tide_site is installed.
 
   Background:
     Given vocabulary "sites" with name "Sites" exists

--- a/modules/tide_site/tide_site.tokens.inc
+++ b/modules/tide_site/tide_site.tokens.inc
@@ -79,7 +79,7 @@ function tide_site_tokens($type, $tokens, array $data, array $options, Bubbleabl
                 $fe_url = $helper->getNodeUrlFromPrimarySite($node);
                 $fe_url = $alias_helper->getPathAliasWithoutSitePrefix(['alias' => $fe_url], $site_url);
                 $replacements[$original] = $fe_url;
-                // Invalidate when the node or its primary site (domain) changes.
+                // Invalidate when the node or its domain changes.
                 $bubbleable_metadata->addCacheableDependency($node);
                 $primary_site = $helper->getEntityPrimarySite($node);
                 if ($primary_site) {

--- a/modules/tide_site/tide_site.tokens.inc
+++ b/modules/tide_site/tide_site.tokens.inc
@@ -16,6 +16,11 @@ function tide_site_token_info_alter(&$data) {
     'description' => t('The base path component without site prefix.'),
   ];
 
+  $data['tokens']['url']['fe_url'] = [
+    'name' => t('Front-end URL'),
+    'description' => t("The node's absolute front-end URL built from its primary site's first domain."),
+  ];
+
   $data['tokens']['node']['publication-parent-prefix'] = [
     'name' => t('Publication parent with prefix'),
     'description' => t('The publication parent to use with linkit'),
@@ -54,6 +59,35 @@ function tide_site_tokens($type, $tokens, array $data, array $options, Bubbleabl
           $value = !($url->getOption('alias')) ? \Drupal::service('path_alias.manager')->getAliasByPath($path, $langcode) : $path;
           $value = preg_replace("/^\/site\-(\d+)\//", '/', $value, 1);
           $replacements[$original] = $value;
+          break;
+
+        case 'fe_url':
+          // [node:url] passes the node's canonical Url object. Recover the node
+          // from the route to build its absolute front-end URL using the
+          // primary site's first domain, with the /site-XXXX/ prefix stripped.
+          if ($url->isRouted() && $url->getRouteName() === 'entity.node.canonical') {
+            $nid = $url->getRouteParameters()['node'] ?? NULL;
+            $node = $nid ? \Drupal::entityTypeManager()->getStorage('node')->load($nid) : NULL;
+            if ($node) {
+              /** @var \Drupal\tide_site\TideSiteHelper $helper */
+              $helper = \Drupal::service('tide_site.helper');
+              /** @var \Drupal\tide_site\AliasStorageHelper $alias_helper */
+              $alias_helper = \Drupal::service('tide_site.alias_storage_helper');
+              $site_url = $helper->getEntityPrimarySiteBaseUrl($node);
+              // No primary site: leave empty instead of emitting /node/123.
+              if ($site_url) {
+                $fe_url = $helper->getNodeUrlFromPrimarySite($node);
+                $fe_url = $alias_helper->getPathAliasWithoutSitePrefix(['alias' => $fe_url], $site_url);
+                $replacements[$original] = $fe_url;
+                // Invalidate when the node or its primary site (domain) changes.
+                $bubbleable_metadata->addCacheableDependency($node);
+                $primary_site = $helper->getEntityPrimarySite($node);
+                if ($primary_site) {
+                  $bubbleable_metadata->addCacheableDependency($primary_site);
+                }
+              }
+            }
+          }
           break;
       }
     }

--- a/src/JsonLdComputedField.php
+++ b/src/JsonLdComputedField.php
@@ -1,0 +1,134 @@
+<?php
+
+namespace Drupal\tide_core;
+
+use Drupal\Core\Field\FieldItemList;
+use Drupal\Core\Render\RenderContext;
+use Drupal\Core\TypedData\ComputedItemListTrait;
+use Drupal\node\NodeInterface;
+use Drupal\schema_metatag\SchemaMetatagManager;
+
+/**
+ * Computed field exposing the assembled JSON-LD string for a node.
+ *
+ * Generic: works for any node bundle. The field is empty unless the bundle
+ * has schema_metatag tags configured (via metatag defaults), so it is safe to
+ * register on every bundle.
+ */
+class JsonLdComputedField extends FieldItemList {
+
+  use ComputedItemListTrait;
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function computeValue() {
+    $entity = $this->getEntity();
+    if (!$entity instanceof NodeInterface || $entity->isNew()) {
+      return;
+    }
+
+    $renderer = \Drupal::service('renderer');
+    $metatag_manager = \Drupal::service('metatag.manager');
+    $module_handler = \Drupal::service('module_handler');
+
+    // Make the node resolvable by the schema BreadcrumbList property type,
+    // which runs deep inside the metatag pipeline without access to the entity.
+    \Drupal::service('tide_core.breadcrumb')->setContextNode($entity);
+
+    // The metatag pipeline generates URLs which leak BubbleableMetadata into
+    // the active render context. Wrap in a context so we don't trigger
+    // LeakedMetadata exceptions when this field is computed outside HTML
+    // rendering (e.g. via JSON:API).
+    $jsonld = $renderer->executeInRenderContext(new RenderContext(), function () use ($entity, $metatag_manager, $module_handler) {
+      $metatags = [];
+      foreach ($metatag_manager->tagsFromEntityWithDefaults($entity) as $tag => $data) {
+        $metatags[$tag] = $data;
+      }
+      $context = ['entity' => $entity];
+      $module_handler->alter('metatags', $metatags, $context);
+      $elements = $metatag_manager->generateElements($metatags, $entity);
+      $elements = $elements['#attached']['html_head'] ?? $elements;
+
+      $items = SchemaMetatagManager::parseJsonld($elements);
+      if (empty($items)) {
+        return '';
+      }
+      return SchemaMetatagManager::encodeJsonld($items) ?: '';
+    });
+
+    if ($jsonld !== '') {
+      $this->list[0] = $this->createItem(0, $this->rewriteUrls($jsonld, $this->getFrontEndBaseUrl($entity)));
+    }
+  }
+
+  /**
+   * Returns the absolute https front-end base URL for a node's primary site.
+   *
+   * @param \Drupal\node\NodeInterface $node
+   *   The node.
+   *
+   * @return string
+   *   The base URL (e.g. "https://www.example.vic.gov.au"), without a trailing
+   *   slash, or an empty string when it cannot be resolved.
+   */
+  protected function getFrontEndBaseUrl(NodeInterface $node): string {
+    if (!\Drupal::moduleHandler()->moduleExists('tide_site')) {
+      return '';
+    }
+    /** @var \Drupal\tide_site\TideSiteHelper $helper */
+    $helper = \Drupal::service('tide_site.helper');
+    $site = $helper->getEntityPrimarySite($node);
+    // Force https regardless of the (possibly http) backend request scheme.
+    return $site ? $helper->getSiteBaseUrl($site, 'https') : '';
+  }
+
+  /**
+   * Rewrites every URL in the JSON-LD to an absolute front-end URL.
+   *
+   * Ensures all URLs are absolute and on the node's front-end domain with an
+   * https scheme: strips the internal /site-XXXX prefix, collapses accidental
+   * double schemes, repoints backend/request-host URLs at the front-end base,
+   * and absolutises any remaining root-relative URLs.
+   *
+   * @param string $json
+   *   The assembled JSON-LD string.
+   * @param string $fe_base
+   *   The front-end base URL to use; falls back to the request host when empty.
+   *
+   * @return string
+   *   The rewritten JSON-LD string.
+   */
+  protected function rewriteUrls(string $json, string $fe_base): string {
+    // Strip the internal /site-XXXX prefix.
+    $json = preg_replace('#/site-\d+(?=/)#', '', $json);
+    $json = preg_replace('#"/site-\d+"#', '"/"', $json);
+
+    // Collapse any accidental double scheme, e.g. http://https://host → https.
+    $json = preg_replace('#"https?://(https?://[^"]*)"#', '"$1"', $json);
+
+    $base = $fe_base !== '' ? $fe_base : \Drupal::request()->getSchemeAndHttpHost();
+    if ($base === '') {
+      return $json;
+    }
+
+    // Repoint any backend/request-host URLs at the front-end base.
+    $request_host = \Drupal::request()->getSchemeAndHttpHost();
+    if ($request_host !== '' && $request_host !== $base) {
+      $json = str_replace('"' . $request_host, '"' . $base, $json);
+    }
+
+    // Force the front-end host onto https.
+    if (preg_match('#^https://(.+)$#', $base, $host)) {
+      $json = str_replace('"http://' . $host[1], '"https://' . $host[1], $json);
+    }
+
+    // Absolutise any remaining root-relative URLs against the front-end base.
+    return preg_replace_callback('#"(/[^"]*)"#', function ($match) use ($base) {
+      // The bare site root maps to the base URL without a trailing slash.
+      $path = $match[1] === '/' ? '' : $match[1];
+      return '"' . $base . $path . '"';
+    }, $json);
+  }
+
+}

--- a/src/JsonLdComputedField.php
+++ b/src/JsonLdComputedField.php
@@ -54,6 +54,26 @@ class JsonLdComputedField extends FieldItemList {
       if (empty($items)) {
         return '';
       }
+
+      // parseJsonld() only skips groups whose sole key is @type, so a group
+      // with an empty value (e.g. a WebPage whose breadcrumb is empty because
+      // the site has breadcrumbs disabled) still renders as "breadcrumb": [].
+      // Trim empty values from each @graph entry and drop entries that end up
+      // empty or @type-only.
+      if (!empty($items['@graph'])) {
+        $graph = [];
+        foreach ($items['@graph'] as $entry) {
+          $trimmed = SchemaMetatagManager::arrayTrim($entry);
+          if (!empty($trimmed)) {
+            $graph[] = $trimmed;
+          }
+        }
+        if (empty($graph)) {
+          return '';
+        }
+        $items['@graph'] = $graph;
+      }
+
       return SchemaMetatagManager::encodeJsonld($items) ?: '';
     });
 
@@ -78,7 +98,9 @@ class JsonLdComputedField extends FieldItemList {
     }
     /** @var \Drupal\tide_site\TideSiteHelper $helper */
     $helper = \Drupal::service('tide_site.helper');
-    $site = $helper->getEntityPrimarySite($node);
+    // Use the site currently being viewed so breadcrumb URLs are on the same
+    // domain the content is served from (multisite-aware), not always primary.
+    $site = \Drupal::service('tide_core.breadcrumb')->getViewingSite($node);
     // Force https regardless of the (possibly http) backend request scheme.
     return $site ? $helper->getSiteBaseUrl($site, 'https') : '';
   }

--- a/src/Plugin/schema_metatag/PropertyType/TideBreadcrumbList.php
+++ b/src/Plugin/schema_metatag/PropertyType/TideBreadcrumbList.php
@@ -35,6 +35,12 @@ class TideBreadcrumbList extends BreadcrumbList {
     $builder = \Drupal::service('tide_core.breadcrumb');
     $trail = $builder->build($node);
 
+    // No trail (e.g. the site has breadcrumbs disabled) means no BreadcrumbList
+    // at all — don't emit a lone current-page item.
+    if (empty($trail)) {
+      return [];
+    }
+
     $items = [];
     $position = 1;
     foreach ($trail as $crumb) {

--- a/src/Plugin/schema_metatag/PropertyType/TideBreadcrumbList.php
+++ b/src/Plugin/schema_metatag/PropertyType/TideBreadcrumbList.php
@@ -1,0 +1,94 @@
+<?php
+
+namespace Drupal\tide_core\Plugin\schema_metatag\PropertyType;
+
+use Drupal\node\NodeInterface;
+use Drupal\schema_metatag\Plugin\schema_metatag\PropertyType\BreadcrumbList;
+
+/**
+ * Tide BreadcrumbList.
+ *
+ * Tide-aware BreadcrumbList that sources its trail from the tide_core
+ * breadcrumb service (which applies hook_tide_breadcrumb_alter()) rather than
+ * running Drupal's BreadcrumbManager against the current route. This makes the
+ * JSON-LD BreadcrumbList correct in headless/JSON:API contexts and overridable
+ * by other modules.
+ *
+ * @see \Drupal\tide_core\TideBreadcrumb
+ */
+class TideBreadcrumbList extends BreadcrumbList {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getItems($input_value) {
+    if (empty($input_value)) {
+      return [];
+    }
+
+    $node = $this->resolveCurrentNode();
+    if (!$node instanceof NodeInterface) {
+      return [];
+    }
+
+    /** @var \Drupal\tide_core\TideBreadcrumb $builder */
+    $builder = \Drupal::service('tide_core.breadcrumb');
+    $trail = $builder->build($node);
+
+    $items = [];
+    $position = 1;
+    foreach ($trail as $crumb) {
+      $title = $crumb['title'] ?? '';
+      $url = $crumb['url'] ?? '';
+      if ($url === '' || $title === '') {
+        continue;
+      }
+      $items[$position] = [
+        '@id' => $url,
+        'name' => $title,
+        'item' => $url,
+      ];
+      $position++;
+    }
+
+    // Append the current page so the trail ends where the user actually is.
+    $current = $node->toUrl()->toString(TRUE)->getGeneratedUrl();
+    if ($current !== '') {
+      $items[$position] = [
+        '@id' => $current,
+        'name' => $node->label(),
+        'item' => $current,
+      ];
+    }
+
+    return $items;
+  }
+
+  /**
+   * Resolves the in-scope node.
+   *
+   * Prefers the node explicitly set on the breadcrumb service by the JSON-LD
+   * computed field (reliable under JSON:API, where the route match is the
+   * JSON:API route), then falls back to the current route's node parameter.
+   *
+   * @return \Drupal\node\NodeInterface|null
+   *   The node, or NULL when none is in scope.
+   */
+  protected function resolveCurrentNode(): ?NodeInterface {
+    /** @var \Drupal\tide_core\TideBreadcrumb $builder */
+    $builder = \Drupal::service('tide_core.breadcrumb');
+    $node = $builder->getContextNode();
+    if ($node instanceof NodeInterface) {
+      return $node;
+    }
+
+    foreach (['node', 'entity'] as $name) {
+      $param = $this->routeMatch->getParameter($name);
+      if ($param instanceof NodeInterface) {
+        return $param;
+      }
+    }
+    return NULL;
+  }
+
+}

--- a/src/TideBreadcrumb.php
+++ b/src/TideBreadcrumb.php
@@ -1,0 +1,323 @@
+<?php
+
+namespace Drupal\tide_core;
+
+use Drupal\Core\Cache\Cache;
+use Drupal\Core\Extension\ModuleHandlerInterface;
+use Drupal\Core\Menu\MenuLinkTreeInterface;
+use Drupal\Core\Menu\MenuTreeParameters;
+use Drupal\node\NodeInterface;
+use Drupal\taxonomy\TermInterface;
+
+/**
+ * Builds a simple, menu-based breadcrumb trail for a node.
+ *
+ * This is the always-on baseline breadcrumb engine that lives in tide_core.
+ * The logic is deliberately minimal: it locates the node inside its primary
+ * site's main menu, walks up the parent chain to collect the ancestor crumbs,
+ * and prepends a "Home" crumb.
+ *
+ * The computed trail is passed through hook_tide_breadcrumb_alter() so other
+ * modules (e.g. a reworked tide_breadcrumbs) can override or augment it before
+ * it is consumed (JSON-LD BreadcrumbList, JSON:API, etc.).
+ *
+ * @see hook_tide_breadcrumb_alter()
+ */
+class TideBreadcrumb {
+
+  /**
+   * The menu link tree service.
+   *
+   * @var \Drupal\Core\Menu\MenuLinkTreeInterface
+   */
+  protected $menuTree;
+
+  /**
+   * The module handler.
+   *
+   * @var \Drupal\Core\Extension\ModuleHandlerInterface
+   */
+  protected $moduleHandler;
+
+  /**
+   * Per-request static cache of computed trails, keyed by node id.
+   *
+   * @var array
+   */
+  protected $trails = [];
+
+  /**
+   * Cache tags discovered while building the current trail.
+   *
+   * @var array
+   */
+  protected $cacheTags = [];
+
+  /**
+   * The node currently in scope (set by the JSON-LD computed field).
+   *
+   * @var \Drupal\node\NodeInterface|null
+   */
+  protected $contextNode;
+
+  /**
+   * Constructs a new TideBreadcrumb service.
+   *
+   * @param \Drupal\Core\Menu\MenuLinkTreeInterface $menu_tree
+   *   The menu link tree service.
+   * @param \Drupal\Core\Extension\ModuleHandlerInterface $module_handler
+   *   The module handler.
+   */
+  public function __construct(MenuLinkTreeInterface $menu_tree, ModuleHandlerInterface $module_handler) {
+    $this->menuTree = $menu_tree;
+    $this->moduleHandler = $module_handler;
+  }
+
+  /**
+   * Builds the breadcrumb trail for a node.
+   *
+   * @param \Drupal\node\NodeInterface $node
+   *   The node to build the trail for.
+   *
+   * @return array
+   *   An ordered list of crumbs, each an array with 'title' and 'url' keys,
+   *   starting with "Home" and ending with the node's parent (the current
+   *   node itself is not included). Empty when there is no resolvable trail.
+   */
+  public function build(NodeInterface $node): array {
+    $nid = $node->id() ?: 'new';
+    if (isset($this->trails[$nid])) {
+      return $this->trails[$nid];
+    }
+
+    $this->cacheTags = $node->getCacheTags();
+    $menu_name = NULL;
+    $trail = [];
+
+    $site_term = $this->getPrimarySite($node);
+    if ($site_term instanceof TermInterface) {
+      $this->cacheTags = Cache::mergeTags($this->cacheTags, $site_term->getCacheTags());
+
+      // Always start at Home.
+      $trail[] = $this->getHomeCrumb();
+
+      // Find the node's ancestors within the site's main menu.
+      $menu_name = $this->getSiteMainMenu($site_term);
+      if ($menu_name && !$node->isNew()) {
+        $this->cacheTags[] = 'config:system.menu.' . $menu_name;
+        $ancestors = $this->getMenuAncestors($menu_name, (string) $node->id());
+        if ($ancestors) {
+          $trail = array_merge($trail, $ancestors);
+        }
+      }
+    }
+
+    // Let other modules override or augment the computed trail. This is the
+    // organic override point: a future tide_breadcrumbs can substitute its
+    // own calculation here, which in turn changes the JSON-LD BreadcrumbList.
+    $context = ['node' => $node, 'menu' => $menu_name];
+    $this->moduleHandler->alter('tide_breadcrumb', $trail, $node, $context);
+
+    $this->trails[$nid] = $trail;
+    return $trail;
+  }
+
+  /**
+   * Sets the node currently in scope.
+   *
+   * Used by the JSON-LD computed field so the schema BreadcrumbList property
+   * type can resolve the node under JSON:API, where the route match does not
+   * carry an entity.node.canonical parameter.
+   *
+   * @param \Drupal\node\NodeInterface $node
+   *   The node in scope.
+   */
+  public function setContextNode(NodeInterface $node): void {
+    $this->contextNode = $node;
+  }
+
+  /**
+   * Returns the node currently in scope, if any.
+   *
+   * @return \Drupal\node\NodeInterface|null
+   *   The node in scope, or NULL.
+   */
+  public function getContextNode(): ?NodeInterface {
+    return $this->contextNode;
+  }
+
+  /**
+   * Resolves the node's primary site taxonomy term.
+   *
+   * @param \Drupal\node\NodeInterface $node
+   *   The node.
+   *
+   * @return \Drupal\taxonomy\TermInterface|null
+   *   The primary site term, or NULL when not set.
+   */
+  protected function getPrimarySite(NodeInterface $node): ?TermInterface {
+    if (!$node->hasField('field_node_primary_site') || $node->get('field_node_primary_site')->isEmpty()) {
+      return NULL;
+    }
+    $term = $node->get('field_node_primary_site')->entity;
+    return $term instanceof TermInterface ? $term : NULL;
+  }
+
+  /**
+   * Resolves the main menu machine name for a site term.
+   *
+   * @param \Drupal\taxonomy\TermInterface $site_term
+   *   The site taxonomy term.
+   *
+   * @return string|null
+   *   The menu machine name, or NULL when not configured.
+   */
+  protected function getSiteMainMenu(TermInterface $site_term): ?string {
+    if ($site_term->hasField('field_site_main_menu') && !$site_term->get('field_site_main_menu')->isEmpty()) {
+      return $site_term->get('field_site_main_menu')->target_id;
+    }
+    return NULL;
+  }
+
+  /**
+   * Builds the "Home" crumb for a site.
+   *
+   * The front-end home of a Tide site is its domain root, so the URL is the
+   * site root ("/"), which downstream resolves to the site's base URL (e.g.
+   * "https://www.example.vic.gov.au") rather than the homepage node alias.
+   *
+   * @return array
+   *   A crumb array with 'title' (always "Home") and 'url'.
+   */
+  protected function getHomeCrumb(): array {
+    return ['title' => 'Home', 'url' => '/'];
+  }
+
+  /**
+   * Returns the ancestor crumbs for a node within a menu.
+   *
+   * Locates the node's link in the menu and returns every crumb above it
+   * (menu root down to the node's parent). The node's own link is omitted.
+   *
+   * @param string $menu_name
+   *   The menu machine name to search.
+   * @param string $target_nid
+   *   The node id to locate.
+   *
+   * @return array
+   *   Ordered ancestor crumbs (shallowest first); empty when the node is not
+   *   in the menu or sits at the top level.
+   */
+  protected function getMenuAncestors(string $menu_name, string $target_nid): array {
+    $parameters = (new MenuTreeParameters())->onlyEnabledLinks();
+    $tree = $this->menuTree->load($menu_name, $parameters);
+    if (empty($tree)) {
+      return [];
+    }
+
+    $path = $this->searchTree($tree, $target_nid);
+    if (!$path) {
+      return [];
+    }
+
+    // Drop the node's own link; keep only its ancestors.
+    array_pop($path);
+    return $path;
+  }
+
+  /**
+   * Recursively searches a menu tree for the path to a node.
+   *
+   * @param \Drupal\Core\Menu\MenuLinkTreeElement[] $tree
+   *   The (sub)tree to search.
+   * @param string $target_nid
+   *   The node id to locate.
+   * @param array $path
+   *   The accumulated path of crumbs to the current branch.
+   *
+   * @return array|null
+   *   The full path of crumbs from the menu root to the matched node
+   *   (inclusive), or NULL when the node is not found in this branch.
+   */
+  protected function searchTree(array $tree, string $target_nid, array $path = []): ?array {
+    foreach ($tree as $element) {
+      $link = $element->link;
+      if (!$link->isEnabled()) {
+        continue;
+      }
+
+      try {
+        $url_object = $link->getUrlObject();
+        $crumb = [
+          'title' => $link->getTitle(),
+          'url' => $url_object->toString(),
+        ];
+      }
+      catch (\Exception $e) {
+        continue;
+      }
+
+      $current_path = $path;
+      $current_path[] = $crumb;
+
+      if ($this->linkPointsToNode($url_object, $target_nid)) {
+        return $current_path;
+      }
+
+      if (!empty($element->subtree)) {
+        $result = $this->searchTree($element->subtree, $target_nid, $current_path);
+        if ($result) {
+          return $result;
+        }
+      }
+    }
+    return NULL;
+  }
+
+  /**
+   * Checks whether a menu link URL points to a given node.
+   *
+   * @param \Drupal\Core\Url $url_object
+   *   The menu link URL object.
+   * @param string $target_nid
+   *   The node id to compare against.
+   *
+   * @return bool
+   *   TRUE when the URL is the canonical route of the target node.
+   */
+  protected function linkPointsToNode($url_object, string $target_nid): bool {
+    if (!$url_object->isRouted() || $url_object->getRouteName() !== 'entity.node.canonical') {
+      return FALSE;
+    }
+    $params = $url_object->getRouteParameters();
+    return isset($params['node']) && (string) $params['node'] === $target_nid;
+  }
+
+  /**
+   * Returns the cache tags for a node's breadcrumb.
+   *
+   * @param \Drupal\node\NodeInterface $node
+   *   The node.
+   *
+   * @return array
+   *   Cache tags that invalidate the breadcrumb when its inputs change.
+   */
+  public function getCacheTags(NodeInterface $node): array {
+    $nid = $node->id() ?: 'new';
+    if (!isset($this->trails[$nid])) {
+      $this->build($node);
+    }
+    return array_unique($this->cacheTags);
+  }
+
+  /**
+   * Returns the cache contexts for breadcrumbs.
+   *
+   * @return array
+   *   Cache contexts.
+   */
+  public function getCacheContexts(): array {
+    return ['url.path', 'languages'];
+  }
+
+}

--- a/src/TideBreadcrumb.php
+++ b/src/TideBreadcrumb.php
@@ -4,18 +4,26 @@ namespace Drupal\tide_core;
 
 use Drupal\Core\Cache\Cache;
 use Drupal\Core\Extension\ModuleHandlerInterface;
+use Drupal\Core\Field\EntityReferenceFieldItemListInterface;
 use Drupal\Core\Menu\MenuLinkTreeInterface;
 use Drupal\Core\Menu\MenuTreeParameters;
 use Drupal\node\NodeInterface;
 use Drupal\taxonomy\TermInterface;
+use Symfony\Component\HttpFoundation\RequestStack;
 
 /**
  * Builds a simple, menu-based breadcrumb trail for a node.
  *
  * This is the always-on baseline breadcrumb engine that lives in tide_core.
- * The logic is deliberately minimal: it locates the node inside its primary
- * site's main menu, walks up the parent chain to collect the ancestor crumbs,
- * and prepends a "Home" crumb.
+ * The logic is deliberately minimal: it locates the node inside the main menu
+ * of the site being viewed, walks up the parent chain to collect the ancestor
+ * crumbs, and prepends a "Home" crumb.
+ *
+ * On a multisite CMS a node can belong to several sites. The trail is built for
+ * the site currently being viewed (the JSON:API "site" query parameter), so the
+ * per-site toggle and menu are resolved against that site rather than the
+ * primary site. It falls back to the primary site when no site is in scope
+ * (e.g. back-end rendering).
  *
  * The computed trail is passed through hook_tide_breadcrumb_alter() so other
  * modules (e.g. a reworked tide_breadcrumbs) can override or augment it before
@@ -38,6 +46,13 @@ class TideBreadcrumb {
    * @var \Drupal\Core\Extension\ModuleHandlerInterface
    */
   protected $moduleHandler;
+
+  /**
+   * The request stack.
+   *
+   * @var \Symfony\Component\HttpFoundation\RequestStack
+   */
+  protected $requestStack;
 
   /**
    * Per-request static cache of computed trails, keyed by node id.
@@ -67,10 +82,13 @@ class TideBreadcrumb {
    *   The menu link tree service.
    * @param \Drupal\Core\Extension\ModuleHandlerInterface $module_handler
    *   The module handler.
+   * @param \Symfony\Component\HttpFoundation\RequestStack $request_stack
+   *   The request stack, used to resolve the site currently being viewed.
    */
-  public function __construct(MenuLinkTreeInterface $menu_tree, ModuleHandlerInterface $module_handler) {
+  public function __construct(MenuLinkTreeInterface $menu_tree, ModuleHandlerInterface $module_handler, RequestStack $request_stack) {
     $this->menuTree = $menu_tree;
     $this->moduleHandler = $module_handler;
+    $this->requestStack = $request_stack;
   }
 
   /**
@@ -86,17 +104,28 @@ class TideBreadcrumb {
    */
   public function build(NodeInterface $node): array {
     $nid = $node->id() ?: 'new';
-    if (isset($this->trails[$nid])) {
-      return $this->trails[$nid];
+    // Resolve the site being viewed first: the trail (and the per-site toggle)
+    // vary per site on a multisite CMS, so the static cache is keyed by both.
+    $site_term = $this->getViewingSite($node);
+    $cache_key = $nid . ':' . ($site_term ? $site_term->id() : 'none');
+    if (isset($this->trails[$cache_key])) {
+      return $this->trails[$cache_key];
     }
 
     $this->cacheTags = $node->getCacheTags();
     $menu_name = NULL;
     $trail = [];
 
-    $site_term = $this->getPrimarySite($node);
     if ($site_term instanceof TermInterface) {
       $this->cacheTags = Cache::mergeTags($this->cacheTags, $site_term->getCacheTags());
+
+      // Per-site switch (default off): only build a breadcrumb when the site
+      // being viewed has it explicitly enabled. When disabled, emit nothing and
+      // skip the alter so other modules cannot re-add a trail for this site.
+      if (!$this->siteBreadcrumbsEnabled($site_term)) {
+        $this->trails[$cache_key] = [];
+        return [];
+      }
 
       // Always start at Home.
       $trail[] = $this->getHomeCrumb();
@@ -115,10 +144,10 @@ class TideBreadcrumb {
     // Let other modules override or augment the computed trail. This is the
     // organic override point: a future tide_breadcrumbs can substitute its
     // own calculation here, which in turn changes the JSON-LD BreadcrumbList.
-    $context = ['node' => $node, 'menu' => $menu_name];
+    $context = ['node' => $node, 'menu' => $menu_name, 'site' => $site_term];
     $this->moduleHandler->alter('tide_breadcrumb', $trail, $node, $context);
 
-    $this->trails[$nid] = $trail;
+    $this->trails[$cache_key] = $trail;
     return $trail;
   }
 
@@ -164,6 +193,66 @@ class TideBreadcrumb {
   }
 
   /**
+   * Resolves the site currently being viewed for a node.
+   *
+   * On a multisite CMS a node can belong to several sites. The headless
+   * front-end requests content with a "site" query parameter, so the breadcrumb
+   * must be built for that site. Only honoured when the node belongs to the
+   * requested site; otherwise the node's primary site is used (e.g. back-end
+   * rendering, where no site parameter is present).
+   *
+   * @param \Drupal\node\NodeInterface $node
+   *   The node.
+   *
+   * @return \Drupal\taxonomy\TermInterface|null
+   *   The site term to build the breadcrumb for, or NULL.
+   */
+  public function getViewingSite(NodeInterface $node): ?TermInterface {
+    $primary = $this->getPrimarySite($node);
+
+    $request = $this->requestStack->getCurrentRequest();
+    $site_id = $request ? $request->query->get('site') : NULL;
+    if (empty($site_id)) {
+      return $primary;
+    }
+
+    foreach ($this->getNodeSiteTerms($node) as $term) {
+      if ((string) $term->id() === (string) $site_id) {
+        return $term;
+      }
+    }
+    return $primary;
+  }
+
+  /**
+   * Returns all site terms a node belongs to (primary and section sites).
+   *
+   * @param \Drupal\node\NodeInterface $node
+   *   The node.
+   *
+   * @return \Drupal\taxonomy\TermInterface[]
+   *   Site terms keyed by term id.
+   */
+  protected function getNodeSiteTerms(NodeInterface $node): array {
+    $terms = [];
+    foreach (['field_node_primary_site', 'field_node_site'] as $field) {
+      if (!$node->hasField($field)) {
+        continue;
+      }
+      $items = $node->get($field);
+      if (!$items instanceof EntityReferenceFieldItemListInterface) {
+        continue;
+      }
+      foreach ($items->referencedEntities() as $term) {
+        if ($term instanceof TermInterface) {
+          $terms[$term->id()] = $term;
+        }
+      }
+    }
+    return $terms;
+  }
+
+  /**
    * Resolves the main menu machine name for a site term.
    *
    * @param \Drupal\taxonomy\TermInterface $site_term
@@ -177,6 +266,23 @@ class TideBreadcrumb {
       return $site_term->get('field_site_main_menu')->target_id;
     }
     return NULL;
+  }
+
+  /**
+   * Checks whether a site has breadcrumbs enabled.
+   *
+   * Controlled by the boolean field_enable_breadcrumbs on the Sites vocabulary.
+   * Defaults to off: breadcrumbs are only built for sites that opt in.
+   *
+   * @param \Drupal\taxonomy\TermInterface $site_term
+   *   The site taxonomy term.
+   *
+   * @return bool
+   *   TRUE when breadcrumbs are enabled for the site.
+   */
+  protected function siteBreadcrumbsEnabled(TermInterface $site_term): bool {
+    return $site_term->hasField('field_enable_breadcrumbs')
+      && (bool) $site_term->get('field_enable_breadcrumbs')->value;
   }
 
   /**
@@ -317,7 +423,8 @@ class TideBreadcrumb {
    *   Cache contexts.
    */
   public function getCacheContexts(): array {
-    return ['url.path', 'languages'];
+    // The trail varies by the site being viewed (JSON:API "site" parameter).
+    return ['url.path', 'url.query_args:site', 'languages'];
   }
 
 }

--- a/src/TideCoreOperation.php
+++ b/src/TideCoreOperation.php
@@ -296,4 +296,53 @@ class TideCoreOperation {
     }
   }
 
+  /**
+   * Enables the JSON-LD engine schema defaults on the node metatag default.
+   *
+   * Ensures the schema modules are installed and that every node bundle emits a
+   * schema.org WebPage + BreadcrumbList in its JSON-LD. The actual trail is
+   * provided by the tide_core breadcrumb service (overridable via
+   * hook_tide_breadcrumb_alter()).
+   *
+   * This lives here (rather than only in config/optional) because the metatag
+   * module ships its own metatag.metatag_defaults.node in config/install, so
+   * tide_core's optional copy is skipped on a fresh install and the schema tags
+   * would never be applied. Idempotent: safe to call on install and update.
+   */
+  public function enableJsonLdSchemaDefaults() {
+    // The JSON-LD engine lives in tide_core, so ensure the schema modules that
+    // power it are installed.
+    $module_installer = \Drupal::service('module_installer');
+    foreach (['schema_metatag', 'schema_web_page'] as $module) {
+      if (!\Drupal::moduleHandler()->moduleExists($module)) {
+        $module_installer->install([$module]);
+      }
+    }
+
+    $storage = \Drupal::entityTypeManager()->getStorage('metatag_defaults');
+    /** @var \Drupal\metatag\Entity\MetatagDefaults|null $defaults */
+    $defaults = $storage->load('node');
+
+    // Create the node defaults from shipped config if they are missing.
+    if ($defaults === NULL) {
+      \Drupal::moduleHandler()->loadInclude('tide_core', 'inc', 'includes/helpers');
+      $config_name = 'metatag.metatag_defaults.node';
+      $config_location = [\Drupal::service('extension.list.module')->getPath('tide_core') . '/config/optional'];
+      $config_read = _tide_read_config($config_name, $config_location, TRUE);
+      if ($config_read) {
+        $storage->createFromStorageRecord($config_read)->save();
+      }
+      return;
+    }
+
+    // Otherwise add the schema tags without clobbering existing values.
+    $tags = $defaults->get('tags') ?: [];
+    $tags += [
+      'schema_web_page_type' => 'WebPage',
+      'schema_web_page_breadcrumb' => 'Yes',
+    ];
+    $defaults->set('tags', $tags);
+    $defaults->save();
+  }
+
 }

--- a/tests/behat/bootstrap/FeatureContext.php
+++ b/tests/behat/bootstrap/FeatureContext.php
@@ -29,6 +29,7 @@ class FeatureContext extends DrupalContext {
   use PathTrait;
   use ResponseTrait;
   use TaxonomyTrait;
+  use TideBreadcrumbTrait;
   use TideCommonTrait;
   use TideExtensionsTrait;
   use TideEntityTrait;

--- a/tests/behat/bootstrap/TideBreadcrumbTrait.php
+++ b/tests/behat/bootstrap/TideBreadcrumbTrait.php
@@ -1,0 +1,188 @@
+<?php
+
+namespace Tide\Tests\Context;
+
+use Behat\Gherkin\Node\TableNode;
+use Drupal\menu_link_content\Entity\MenuLinkContent;
+use Symfony\Component\HttpFoundation\Request;
+
+/**
+ * Steps for testing the tide_core JSON-LD breadcrumb (TideBreadcrumb).
+ *
+ * The breadcrumb engine lives in tide_core: it builds a menu-based trail for a
+ * node, gated per-site by field_enable_breadcrumbs, and exposes it through the
+ * node's computed json_ld field (schema.org BreadcrumbList). These steps set up
+ * menu links pointing to nodes and assert against the computed json_ld value.
+ *
+ * Relies on MenuTrait (loadMenuByLabel/loadMenuLinkByTitle and the $menuLinks
+ * cleanup) being present on the same context class.
+ */
+trait TideBreadcrumbTrait {
+
+  /**
+   * Creates menu links that point to nodes, resolved by node title.
+   *
+   * Unlike the generic ":menu_name menu_links:" step, the target node is
+   * resolved by title, so scenarios never need to know node IDs. Hierarchy is
+   * expressed by referencing a previously-created link title in "parent".
+   *
+   * | title        | node           | parent       |
+   * | Parent crumb | BC Parent page |              |
+   * | Child crumb  | BC Child page  | Parent crumb |
+   *
+   * @Given :menu_name menu_links for nodes:
+   */
+  public function tideBreadcrumbMenuLinksForNodes($menu_name, TableNode $table) {
+    $menu = $this->loadMenuByLabel($menu_name);
+    foreach ($table->getHash() as $row) {
+      $node = $this->tideBreadcrumbGetNodeByTitle($row['node']);
+      $values = [
+        'title' => $row['title'],
+        'menu_name' => $menu->id(),
+        'link' => ['uri' => 'entity:node/' . $node->id()],
+        'enabled' => 1,
+      ];
+      if (!empty($row['parent'])) {
+        $parent = $this->loadMenuLinkByTitle($row['parent'], $menu_name);
+        $values['parent'] = 'menu_link_content:' . $parent->uuid();
+      }
+      $link = MenuLinkContent::create($values);
+      $link->save();
+      // Tracked by MenuTrait::menuCleanAll() for automatic cleanup.
+      $this->menuLinks[] = $link;
+    }
+  }
+
+  /**
+   * Assigns a menu as the main menu of a Sites term.
+   *
+   * Set explicitly (not via a field column) because field_site_main_menu
+   * references a menu config entity, which the generic term-creation step
+   * does not resolve by label.
+   *
+   * @Given the main menu of site :site_name is :menu_label
+   */
+  public function tideBreadcrumbSetSiteMainMenu($site_name, $menu_label) {
+    $menu = $this->loadMenuByLabel($menu_label);
+    $term = $this->tideBreadcrumbGetSiteTermByName($site_name);
+    $term->set('field_site_main_menu', $menu->id());
+    $term->save();
+  }
+
+  /**
+   * Asserts a node's computed json_ld contains a string.
+   *
+   * @Then the JSON-LD of :type :title should contain :text
+   */
+  public function tideBreadcrumbJsonLdContains($type, $title, $text) {
+    $json = $this->tideBreadcrumbGetJsonLd($type, $title);
+    if (strpos($json, $text) === FALSE) {
+      throw new \Exception(sprintf("The JSON-LD of %s '%s' does not contain '%s'.\nActual:\n%s", $type, $title, $text, $json));
+    }
+  }
+
+  /**
+   * Asserts a node's computed json_ld does not contain a string.
+   *
+   * @Then the JSON-LD of :type :title should not contain :text
+   */
+  public function tideBreadcrumbJsonLdNotContains($type, $title, $text) {
+    $json = $this->tideBreadcrumbGetJsonLd($type, $title);
+    if (strpos($json, $text) !== FALSE) {
+      throw new \Exception(sprintf("The JSON-LD of %s '%s' unexpectedly contains '%s'.\nActual:\n%s", $type, $title, $text, $json));
+    }
+  }
+
+  /**
+   * Asserts a node's json_ld, as viewed on a given site, contains a string.
+   *
+   * Simulates the headless front-end requesting the node with ?site=<tid>, so
+   * the multisite-aware breadcrumb is computed for that site.
+   *
+   * @Then with site :site_name the JSON-LD of :type :title should contain :text
+   */
+  public function tideBreadcrumbJsonLdWithSiteContains($site_name, $type, $title, $text) {
+    $json = $this->tideBreadcrumbGetJsonLdForSite($type, $title, $site_name);
+    if (strpos($json, $text) === FALSE) {
+      throw new \Exception(sprintf("With site '%s', the JSON-LD of %s '%s' does not contain '%s'.\nActual:\n%s", $site_name, $type, $title, $text, $json));
+    }
+  }
+
+  /**
+   * Asserts a node's json_ld, as viewed on a given site, lacks a string.
+   *
+   * @Then with site :site_name the JSON-LD of :type :title should not contain :text
+   */
+  public function tideBreadcrumbJsonLdWithSiteNotContains($site_name, $type, $title, $text) {
+    $json = $this->tideBreadcrumbGetJsonLdForSite($type, $title, $site_name);
+    if (strpos($json, $text) !== FALSE) {
+      throw new \Exception(sprintf("With site '%s', the JSON-LD of %s '%s' unexpectedly contains '%s'.\nActual:\n%s", $site_name, $type, $title, $text, $json));
+    }
+  }
+
+  /**
+   * Computes a node's json_ld as if viewed on a given site (?site=<tid>).
+   */
+  protected function tideBreadcrumbGetJsonLdForSite($type, $title, $site_name) {
+    $site = $this->tideBreadcrumbGetSiteTermByName($site_name);
+    $node = $this->tideBreadcrumbGetNodeByTitle($title, $type);
+    $request_stack = \Drupal::requestStack();
+    // Push a request carrying the site parameter the front-end would send.
+    $request_stack->push(Request::create('/', 'GET', ['site' => $site->id()]));
+    try {
+      \Drupal::entityTypeManager()->getStorage('node')->resetCache([$node->id()]);
+      $node = $this->tideBreadcrumbGetNodeByTitle($title, $type);
+      return (string) ($node->get('json_ld')->value ?? '');
+    }
+    finally {
+      $request_stack->pop();
+    }
+  }
+
+  /**
+   * Returns the freshly computed json_ld value of a node.
+   */
+  protected function tideBreadcrumbGetJsonLd($type, $title) {
+    $node = $this->tideBreadcrumbGetNodeByTitle($title, $type);
+    // Recompute against the current menu/site state.
+    \Drupal::entityTypeManager()->getStorage('node')->resetCache([$node->id()]);
+    $node = $this->tideBreadcrumbGetNodeByTitle($title, $type);
+    return (string) ($node->get('json_ld')->value ?? '');
+  }
+
+  /**
+   * Loads a node by title (and optional bundle).
+   *
+   * @return \Drupal\node\NodeInterface
+   *   The node.
+   */
+  protected function tideBreadcrumbGetNodeByTitle($title, $type = NULL) {
+    $properties = ['title' => $title];
+    if ($type) {
+      $properties['type'] = $type;
+    }
+    $nodes = \Drupal::entityTypeManager()->getStorage('node')->loadByProperties($properties);
+    if (empty($nodes)) {
+      throw new \Exception(sprintf("Could not find a node with title '%s'.", $title));
+    }
+    return reset($nodes);
+  }
+
+  /**
+   * Loads a Sites vocabulary term by name.
+   *
+   * @return \Drupal\taxonomy\TermInterface
+   *   The site term.
+   */
+  protected function tideBreadcrumbGetSiteTermByName($name) {
+    $terms = \Drupal::entityTypeManager()->getStorage('taxonomy_term')->loadByProperties([
+      'vid' => 'sites',
+      'name' => $name,
+    ]);
+    if (empty($terms)) {
+      throw new \Exception(sprintf("Could not find a Sites term named '%s'.", $name));
+    }
+    return reset($terms);
+  }
+
+}

--- a/tests/behat/features/schema_breadcrumb.feature
+++ b/tests/behat/features/schema_breadcrumb.feature
@@ -1,0 +1,77 @@
+@tide @breadcrumb @schema
+Feature: JSON-LD breadcrumb (tide_core)
+
+  As a Tide site owner, I want each page's JSON-LD to include a menu-based
+  Schema.org BreadcrumbList, gated per site, so that structured data reflects
+  the site's information architecture.
+
+  The breadcrumb engine lives in tide_core: it builds the trail from the node's
+  primary-site main menu (starting at the site root "Home"), is switched on/off
+  per site via the "Enable breadcrumbs" field, and is exposed through the node's
+  computed json_ld field.
+
+  Background:
+    Given vocabulary "sites" with name "Sites" exists
+    And no "sites" terms:
+      | Breadcrumb On  |
+      | Breadcrumb Off |
+      | MS Site On     |
+      | MS Site Off    |
+    And no menus:
+      | Breadcrumb Menu |
+
+  @api
+  Scenario: An enabled site emits a menu-based BreadcrumbList starting at Home
+    Given menus:
+      | label           |
+      | Breadcrumb Menu |
+    And sites terms:
+      | name          | field_site_domains        | field_enable_breadcrumbs |
+      | Breadcrumb On | www.breadcrumb-on.example | 1                        |
+    And the main menu of site "Breadcrumb On" is "Breadcrumb Menu"
+    And test content:
+      | title          | field_node_primary_site | field_node_site |
+      | BC Parent page | Breadcrumb On           | Breadcrumb On   |
+      | BC Child page  | Breadcrumb On           | Breadcrumb On   |
+    And "Breadcrumb Menu" menu_links for nodes:
+      | title        | node           | parent       |
+      | Parent crumb | BC Parent page |              |
+      | Child crumb  | BC Child page  | Parent crumb |
+
+    # The child page sits under "Parent crumb" in the site menu, so its trail is
+    # Home > Parent crumb > (current page).
+    Then the JSON-LD of "test" "BC Child page" should contain "BreadcrumbList"
+    # Home is the first crumb and points at the site root (absolute, https).
+    And the JSON-LD of "test" "BC Child page" should contain "Home"
+    And the JSON-LD of "test" "BC Child page" should contain "https://www.breadcrumb-on.example"
+    # The ancestor uses the menu link title, and the current page is appended.
+    And the JSON-LD of "test" "BC Child page" should contain "Parent crumb"
+    And the JSON-LD of "test" "BC Child page" should contain "BC Child page"
+
+  @api
+  Scenario: A disabled site emits no BreadcrumbList
+    Given sites terms:
+      | name           | field_site_domains         | field_enable_breadcrumbs |
+      | Breadcrumb Off | www.breadcrumb-off.example | 0                        |
+    And test content:
+      | title       | field_node_primary_site | field_node_site |
+      | BC Off page | Breadcrumb Off          | Breadcrumb Off  |
+
+    # Breadcrumbs are off for this site, so no BreadcrumbList is emitted at all.
+    Then the JSON-LD of "test" "BC Off page" should not contain "BreadcrumbList"
+
+  @api
+  Scenario: The breadcrumb follows the site being viewed on a multisite node
+    Given sites terms:
+      | name        | field_site_domains | field_enable_breadcrumbs |
+      | MS Site On  | www.ms-on.example  | 1                        |
+      | MS Site Off | www.ms-off.example | 0                        |
+    And test content:
+      | title     | field_node_primary_site | field_node_site         |
+      | MS Shared | MS Site On              | MS Site On, MS Site Off |
+
+    # Same node, viewed on the enabled site: breadcrumb present, on its domain.
+    Then with site "MS Site On" the JSON-LD of "test" "MS Shared" should contain "BreadcrumbList"
+    And with site "MS Site On" the JSON-LD of "test" "MS Shared" should contain "https://www.ms-on.example"
+    # Viewed on the disabled site: no breadcrumb, even though it is enabled elsewhere.
+    And with site "MS Site Off" the JSON-LD of "test" "MS Shared" should not contain "BreadcrumbList"

--- a/tide_core.api.php
+++ b/tide_core.api.php
@@ -1,0 +1,56 @@
+<?php
+
+/**
+ * @file
+ * Hooks provided by the Tide Core module.
+ */
+
+use Drupal\node\NodeInterface;
+
+/**
+ * @addtogroup hooks
+ * @{
+ */
+
+/**
+ * Alter the breadcrumb trail tide_core computes for a node.
+ *
+ * Tide Core builds a simple, menu-based breadcrumb trail for a node (the
+ * "Home" crumb followed by the node's ancestor menu links) and passes it
+ * through this alter before it is consumed — most notably by the schema.org
+ * BreadcrumbList that feeds the node's JSON-LD computed field.
+ *
+ * This is the supported override point: a module can replace the baseline
+ * trail with its own calculation (for example a taxonomy-driven or
+ * multi-site trail) and thereby change the JSON-LD output, without tide_core
+ * needing to know about it.
+ *
+ * @param array $trail
+ *   The breadcrumb trail, an ordered list of crumbs. Each crumb is an array
+ *   with:
+ *   - title: (string) The visible label of the crumb.
+ *   - url: (string) The crumb URL. May be a site-relative path (with a
+ *     /site-XXXX/ prefix); downstream consumers normalise it to an absolute
+ *     front-end URL. The current node is NOT included — consumers append it.
+ * @param \Drupal\node\NodeInterface $node
+ *   The node the trail is being built for.
+ * @param array $context
+ *   Additional context:
+ *   - node: (\Drupal\node\NodeInterface) The node (same as $node).
+ *   - menu: (string|null) The machine name of the site main menu searched,
+ *     or NULL when the node has no resolvable primary site menu.
+ *
+ * @see \Drupal\tide_core\TideBreadcrumb::build()
+ */
+function hook_tide_breadcrumb_alter(array &$trail, NodeInterface $node, array $context) {
+  // Example: prepend an extra crumb for a specific content type.
+  if ($node->bundle() === 'news') {
+    array_splice($trail, 1, 0, [
+      ['title' => 'News', 'url' => '/news'],
+    ]);
+  }
+}
+
+/**
+ * @} End of "addtogroup hooks".
+ */

--- a/tide_core.info.yml
+++ b/tide_core.info.yml
@@ -62,6 +62,8 @@ dependencies:
   - media_entity_audio:media_entity_audio
   - metatag:metatag
   - metatag:metatag_open_graph
+  - schema_metatag:schema_metatag
+  - schema_metatag:schema_web_page
   - override_node_options:override_node_options
   - paragraphs:paragraphs
   - paragraphs:paragraphs_library

--- a/tide_core.install
+++ b/tide_core.install
@@ -68,6 +68,13 @@ function tide_core_install() {
 
   // Assign permissions for CKEditor template usage.
   $tideCoreOperation->assignCkeditorTemplatesPermission();
+
+  // Enable the JSON-LD engine schema defaults (WebPage + BreadcrumbList) on the
+  // node metatag default. Done here rather than via config/optional because the
+  // metatag module ships its own metatag.metatag_defaults.node in config/install
+  // that would otherwise shadow ours, and hook_update_N does not run on a fresh
+  // install. Mirrors tide_core_update_10041() for existing sites.
+  $tideCoreOperation->enableJsonLdSchemaDefaults();
 }
 
 /**
@@ -1439,36 +1446,40 @@ function tide_core_update_10040() {
  * Enable the JSON-LD engine: schema modules + node WebPage/breadcrumb defaults.
  */
 function tide_core_update_10041() {
-  // The JSON-LD engine now lives in tide_core, so ensure the schema modules
-  // that power it are installed.
-  \Drupal::service('module_installer')->install(['schema_metatag', 'schema_web_page']);
+  // Enable the schema modules and add the WebPage + breadcrumb schema default at
+  // the node level so every bundle emits a schema.org BreadcrumbList in its
+  // JSON-LD. The actual trail is provided by the tide_core breadcrumb service
+  // (overridable via hook_tide_breadcrumb_alter()). Shared with hook_install()
+  // so fresh installs get the same defaults.
+  (new TideCoreOperation())->enableJsonLdSchemaDefaults();
+}
 
-  // Enable a WebPage + breadcrumb schema default at the node level so every
-  // bundle emits a schema.org BreadcrumbList in its JSON-LD. The actual trail
-  // is provided by the tide_core breadcrumb service (overridable via
-  // hook_tide_breadcrumb_alter()).
-  $storage = \Drupal::entityTypeManager()->getStorage('metatag_defaults');
-  /** @var \Drupal\metatag\Entity\MetatagDefaults|null $defaults */
-  $defaults = $storage->load('node');
+/**
+ * Install the per-site 'Enable breadcrumbs' field on the Sites vocabulary.
+ */
+function tide_core_update_10042() {
+  \Drupal::moduleHandler()->loadInclude('tide_core', 'inc', 'includes/helpers');
+  $config_location = [\Drupal::service('extension.list.module')->getPath('tide_core') . '/config/install'];
 
-  // Create the node defaults from shipped config if they are missing.
-  if ($defaults === NULL) {
-    \Drupal::moduleHandler()->loadInclude('tide_core', 'inc', 'includes/helpers');
-    $config_name = 'metatag.metatag_defaults.node';
-    $config_location = [\Drupal::service('extension.list.module')->getPath('tide_core') . '/config/optional'];
-    $config_read = _tide_read_config($config_name, $config_location, TRUE);
-    if ($config_read) {
-      $storage->createFromStorageRecord($config_read)->save();
+  // Field storage.
+  $storage_config = 'field.storage.taxonomy_term.field_enable_breadcrumbs';
+  $field_storage = \Drupal::entityTypeManager()->getStorage('field_storage_config');
+  $storage_id = $field_storage->getIDFromConfigName($storage_config, $field_storage->getEntityType()->getConfigPrefix());
+  if ($field_storage->load($storage_id) === NULL) {
+    $record = _tide_read_config($storage_config, $config_location, TRUE);
+    if ($record) {
+      $field_storage->createFromStorageRecord($record)->save();
     }
-    return;
   }
 
-  // Otherwise add the schema tags without clobbering existing values.
-  $tags = $defaults->get('tags') ?: [];
-  $tags += [
-    'schema_web_page_type' => 'WebPage',
-    'schema_web_page_breadcrumb' => 'Yes',
-  ];
-  $defaults->set('tags', $tags);
-  $defaults->save();
+  // Field instance on the Sites vocabulary.
+  $field_config = 'field.field.taxonomy_term.sites.field_enable_breadcrumbs';
+  $field = \Drupal::entityTypeManager()->getStorage('field_config');
+  $field_id = $field->getIDFromConfigName($field_config, $field->getEntityType()->getConfigPrefix());
+  if ($field->load($field_id) === NULL) {
+    $record = _tide_read_config($field_config, $config_location, TRUE);
+    if ($record) {
+      $field->createFromStorageRecord($record)->save();
+    }
+  }
 }

--- a/tide_core.install
+++ b/tide_core.install
@@ -70,10 +70,7 @@ function tide_core_install() {
   $tideCoreOperation->assignCkeditorTemplatesPermission();
 
   // Enable the JSON-LD engine schema defaults (WebPage + BreadcrumbList) on the
-  // node metatag default. Done here rather than via config/optional because the
-  // metatag module ships its own metatag.metatag_defaults.node in config/install
-  // that would otherwise shadow ours, and hook_update_N does not run on a fresh
-  // install. Mirrors tide_core_update_10041() for existing sites.
+  // node metatag default.
   $tideCoreOperation->enableJsonLdSchemaDefaults();
 }
 
@@ -1446,8 +1443,8 @@ function tide_core_update_10040() {
  * Enable the JSON-LD engine: schema modules + node WebPage/breadcrumb defaults.
  */
 function tide_core_update_10041() {
-  // Enable the schema modules and add the WebPage + breadcrumb schema default at
-  // the node level so every bundle emits a schema.org BreadcrumbList in its
+  // Enable the schema modules and add the WebPage + breadcrumb schema default
+  // at the node level so every bundle emits a schema.org BreadcrumbList in its
   // JSON-LD. The actual trail is provided by the tide_core breadcrumb service
   // (overridable via hook_tide_breadcrumb_alter()). Shared with hook_install()
   // so fresh installs get the same defaults.
@@ -1481,5 +1478,25 @@ function tide_core_update_10042() {
     if ($record) {
       $field->createFromStorageRecord($record)->save();
     }
+  }
+}
+
+/**
+ * Show the per-site 'Enable breadcrumbs' field on the Sites term form.
+ */
+function tide_core_update_10043() {
+  /** @var \Drupal\Core\Entity\Display\EntityFormDisplayInterface|null $form_display */
+  $form_display = \Drupal::entityTypeManager()
+    ->getStorage('entity_form_display')
+    ->load('taxonomy_term.sites.default');
+  if ($form_display && $form_display->getComponent('field_enable_breadcrumbs') === NULL) {
+    $form_display->setComponent('field_enable_breadcrumbs', [
+      'type' => 'boolean_checkbox',
+      'weight' => 28,
+      'region' => 'content',
+      'settings' => ['display_label' => TRUE],
+      'third_party_settings' => [],
+    ]);
+    $form_display->save();
   }
 }

--- a/tide_core.install
+++ b/tide_core.install
@@ -1434,3 +1434,41 @@ function tide_core_update_10040() {
     }
   }
 }
+
+/**
+ * Enable the JSON-LD engine: schema modules + node WebPage/breadcrumb defaults.
+ */
+function tide_core_update_10041() {
+  // The JSON-LD engine now lives in tide_core, so ensure the schema modules
+  // that power it are installed.
+  \Drupal::service('module_installer')->install(['schema_metatag', 'schema_web_page']);
+
+  // Enable a WebPage + breadcrumb schema default at the node level so every
+  // bundle emits a schema.org BreadcrumbList in its JSON-LD. The actual trail
+  // is provided by the tide_core breadcrumb service (overridable via
+  // hook_tide_breadcrumb_alter()).
+  $storage = \Drupal::entityTypeManager()->getStorage('metatag_defaults');
+  /** @var \Drupal\metatag\Entity\MetatagDefaults|null $defaults */
+  $defaults = $storage->load('node');
+
+  // Create the node defaults from shipped config if they are missing.
+  if ($defaults === NULL) {
+    \Drupal::moduleHandler()->loadInclude('tide_core', 'inc', 'includes/helpers');
+    $config_name = 'metatag.metatag_defaults.node';
+    $config_location = [\Drupal::service('extension.list.module')->getPath('tide_core') . '/config/optional'];
+    $config_read = _tide_read_config($config_name, $config_location, TRUE);
+    if ($config_read) {
+      $storage->createFromStorageRecord($config_read)->save();
+    }
+    return;
+  }
+
+  // Otherwise add the schema tags without clobbering existing values.
+  $tags = $defaults->get('tags') ?: [];
+  $tags += [
+    'schema_web_page_type' => 'WebPage',
+    'schema_web_page_breadcrumb' => 'Yes',
+  ];
+  $defaults->set('tags', $tags);
+  $defaults->save();
+}

--- a/tide_core.module
+++ b/tide_core.module
@@ -25,7 +25,9 @@ use Drupal\node\NodeInterface;
 use Drupal\paragraphs\Entity\Paragraph;
 use Drupal\redirect\Entity\Redirect;
 use Drupal\scheduled_transitions\Routing\ScheduledTransitionsRouteProvider;
+use Drupal\tide_core\JsonLdComputedField;
 use Drupal\tide_core\Plugin\CornerGraphicField;
+use Drupal\tide_core\Plugin\schema_metatag\PropertyType\TideBreadcrumbList;
 use Drupal\tide_core\Render\Element\AdminToolbar;
 use Drupal\user\RoleInterface;
 use Drupal\views\ViewExecutable;
@@ -959,5 +961,44 @@ function tide_core_form_views_exposed_form_alter(&$form, FormStateInterface $for
   // Sort Topic filter options alphabetically by label.
   if (!empty($form['field_topic_target_id']['#options'])) {
     asort($form['field_topic_target_id']['#options']);
+  }
+}
+
+/**
+ * Implements hook_entity_bundle_field_info().
+ *
+ * Registers a generic, read-only 'json_ld' computed field on every node bundle.
+ * The field assembles the schema_metatag JSON-LD string for the node and is
+ * empty unless the bundle has schema_metatag tags configured (via metatag
+ * defaults), so it is safe to expose everywhere.
+ */
+function tide_core_entity_bundle_field_info(EntityTypeInterface $entity_type, $bundle, array $base_field_definitions) {
+  $fields = [];
+
+  if ($entity_type->id() === 'node') {
+    $fields['json_ld'] = BaseFieldDefinition::create('string_long')
+      ->setLabel(t('JSON-LD'))
+      ->setDescription(t('Pre-assembled JSON-LD string for this node, ready to be injected into a script[type="application/ld+json"] tag by the headless frontend.'))
+      ->setComputed(TRUE)
+      ->setClass(JsonLdComputedField::class)
+      ->setReadOnly(TRUE);
+  }
+
+  return $fields;
+}
+
+/**
+ * Implements hook_schema_metatag_property_type_plugins_alter().
+ *
+ * Replaces contrib's BreadcrumbList property type with the Tide-aware subclass
+ * that sources the trail from the tide_core breadcrumb service (which applies
+ * hook_tide_breadcrumb_alter()) and works under JSON:API.
+ *
+ * @see \Drupal\tide_core\Plugin\schema_metatag\PropertyType\TideBreadcrumbList
+ */
+function tide_core_schema_metatag_property_type_plugins_alter(array &$definitions) {
+  if (isset($definitions['breadcrumb_list'])) {
+    $definitions['breadcrumb_list']['class'] = TideBreadcrumbList::class;
+    $definitions['breadcrumb_list']['provider'] = 'tide_core';
   }
 }

--- a/tide_core.services.yml
+++ b/tide_core.services.yml
@@ -22,6 +22,11 @@ services:
   tide_core.autocomplete_matcher:
     class: Drupal\tide_core\EntityAutocompleteMatcher
     arguments: ['@plugin.manager.entity_reference_selection']
+  tide_core.breadcrumb:
+    class: Drupal\tide_core\TideBreadcrumb
+    arguments:
+      - '@menu.link_tree'
+      - '@module_handler'
   tide_core.common_services:
     class: Drupal\tide_core\TideCommonServices
   tide_core.system_info_service:

--- a/tide_core.services.yml
+++ b/tide_core.services.yml
@@ -27,6 +27,7 @@ services:
     arguments:
       - '@menu.link_tree'
       - '@module_handler'
+      - '@request_stack'
   tide_core.common_services:
     class: Drupal\tide_core\TideCommonServices
   tide_core.system_info_service:


### PR DESCRIPTION
### Jira
https://digital-vic.atlassian.net/browse/SD-1700

### Change
This PR primarily decouples `schema.org` from the `tide_breadcrumbs` [PR-789](https://github.com/dpc-sdp/tide_core/pull/789) for two reasons:
- A large number of our sites do not use tide_breadcrumbs.
- tide_breadcrumbs has an unresolved bug that causes page breakage, though it does not affect vic.gov.au.

### Document
https://digital-vic.atlassian.net/wiki/spaces/SDP/pages/4457562119/Structured+Data+Schema.org+JSON+LD+in+tide

It connects to `tide_breadcrumbs` via a custom hook, if `tide_breadcrumbs` is enabled, the breadcrumbs will be provided by it.

- https://github.com/dpc-sdp/tide_core/pull/789


