### PR TITLE
[SD-1832] Fix JSON-LD breadcrumb performance: depth-bounded menu lookup

### DIFF
--- a/src/TideBreadcrumb.php
+++ b/src/TideBreadcrumb.php
@@ -5,8 +5,7 @@ namespace Drupal\tide_core;
 use Drupal\Core\Cache\Cache;
 use Drupal\Core\Extension\ModuleHandlerInterface;
 use Drupal\Core\Field\EntityReferenceFieldItemListInterface;
-use Drupal\Core\Menu\MenuLinkTreeInterface;
-use Drupal\Core\Menu\MenuTreeParameters;
+use Drupal\Core\Menu\MenuLinkManagerInterface;
 use Drupal\node\NodeInterface;
 use Drupal\taxonomy\TermInterface;
 use Symfony\Component\HttpFoundation\RequestStack;
@@ -34,11 +33,11 @@ use Symfony\Component\HttpFoundation\RequestStack;
 class TideBreadcrumb {
 
   /**
-   * The menu link tree service.
+   * The menu link plugin manager.
    *
-   * @var \Drupal\Core\Menu\MenuLinkTreeInterface
+   * @var \Drupal\Core\Menu\MenuLinkManagerInterface
    */
-  protected $menuTree;
+  protected $menuLinkManager;
 
   /**
    * The module handler.
@@ -55,18 +54,18 @@ class TideBreadcrumb {
   protected $requestStack;
 
   /**
-   * Per-request static cache of computed trails, keyed by node id.
+   * Per-request static cache of computed trails, keyed by node and site id.
    *
    * @var array
    */
   protected $trails = [];
 
   /**
-   * Cache tags discovered while building the current trail.
+   * Cache tags discovered while building each trail, keyed like $trails.
    *
    * @var array
    */
-  protected $cacheTags = [];
+  protected $trailTags = [];
 
   /**
    * The node currently in scope (set by the JSON-LD computed field).
@@ -78,15 +77,15 @@ class TideBreadcrumb {
   /**
    * Constructs a new TideBreadcrumb service.
    *
-   * @param \Drupal\Core\Menu\MenuLinkTreeInterface $menu_tree
-   *   The menu link tree service.
+   * @param \Drupal\Core\Menu\MenuLinkManagerInterface $menu_link_manager
+   *   The menu link plugin manager.
    * @param \Drupal\Core\Extension\ModuleHandlerInterface $module_handler
    *   The module handler.
    * @param \Symfony\Component\HttpFoundation\RequestStack $request_stack
    *   The request stack, used to resolve the site currently being viewed.
    */
-  public function __construct(MenuLinkTreeInterface $menu_tree, ModuleHandlerInterface $module_handler, RequestStack $request_stack) {
-    $this->menuTree = $menu_tree;
+  public function __construct(MenuLinkManagerInterface $menu_link_manager, ModuleHandlerInterface $module_handler, RequestStack $request_stack) {
+    $this->menuLinkManager = $menu_link_manager;
     $this->moduleHandler = $module_handler;
     $this->requestStack = $request_stack;
   }
@@ -112,18 +111,19 @@ class TideBreadcrumb {
       return $this->trails[$cache_key];
     }
 
-    $this->cacheTags = $node->getCacheTags();
+    $tags = $node->getCacheTags();
     $menu_name = NULL;
     $trail = [];
 
     if ($site_term instanceof TermInterface) {
-      $this->cacheTags = Cache::mergeTags($this->cacheTags, $site_term->getCacheTags());
+      $tags = Cache::mergeTags($tags, $site_term->getCacheTags());
 
       // Per-site switch (default off): only build a breadcrumb when the site
       // being viewed has it explicitly enabled. When disabled, emit nothing and
       // skip the alter so other modules cannot re-add a trail for this site.
       if (!$this->siteBreadcrumbsEnabled($site_term)) {
         $this->trails[$cache_key] = [];
+        $this->trailTags[$cache_key] = $tags;
         return [];
       }
 
@@ -133,7 +133,7 @@ class TideBreadcrumb {
       // Find the node's ancestors within the site's main menu.
       $menu_name = $this->getSiteMainMenu($site_term);
       if ($menu_name && !$node->isNew()) {
-        $this->cacheTags[] = 'config:system.menu.' . $menu_name;
+        $tags[] = 'config:system.menu.' . $menu_name;
         $ancestors = $this->getMenuAncestors($menu_name, (string) $node->id());
         if ($ancestors) {
           $trail = array_merge($trail, $ancestors);
@@ -148,6 +148,7 @@ class TideBreadcrumb {
     $this->moduleHandler->alter('tide_breadcrumb', $trail, $node, $context);
 
     $this->trails[$cache_key] = $trail;
+    $this->trailTags[$cache_key] = $tags;
     return $trail;
   }
 
@@ -302,8 +303,10 @@ class TideBreadcrumb {
   /**
    * Returns the ancestor crumbs for a node within a menu.
    *
-   * Locates the node's link in the menu and returns every crumb above it
-   * (menu root down to the node's parent). The node's own link is omitted.
+   * Looks the node's link up directly in the menu tree storage (an indexed
+   * query on the link's route) and walks the parent chain upwards, so the
+   * cost scales with the trail depth rather than the size of the menu. URLs
+   * are only generated for the ancestors that end up in the trail.
    *
    * @param string $menu_name
    *   The menu machine name to search.
@@ -315,88 +318,41 @@ class TideBreadcrumb {
    *   in the menu or sits at the top level.
    */
   protected function getMenuAncestors(string $menu_name, string $target_nid): array {
-    $parameters = (new MenuTreeParameters())->onlyEnabledLinks();
-    $tree = $this->menuTree->load($menu_name, $parameters);
-    if (empty($tree)) {
-      return [];
-    }
+    $links = $this->menuLinkManager->loadLinksByRoute('entity.node.canonical', ['node' => $target_nid], $menu_name);
 
-    $path = $this->searchTree($tree, $target_nid);
-    if (!$path) {
-      return [];
-    }
-
-    // Drop the node's own link; keep only its ancestors.
-    array_pop($path);
-    return $path;
-  }
-
-  /**
-   * Recursively searches a menu tree for the path to a node.
-   *
-   * @param \Drupal\Core\Menu\MenuLinkTreeElement[] $tree
-   *   The (sub)tree to search.
-   * @param string $target_nid
-   *   The node id to locate.
-   * @param array $path
-   *   The accumulated path of crumbs to the current branch.
-   *
-   * @return array|null
-   *   The full path of crumbs from the menu root to the matched node
-   *   (inclusive), or NULL when the node is not found in this branch.
-   */
-  protected function searchTree(array $tree, string $target_nid, array $path = []): ?array {
-    foreach ($tree as $element) {
-      $link = $element->link;
-      if (!$link->isEnabled()) {
-        continue;
+    $link = NULL;
+    foreach ($links as $candidate) {
+      if ($candidate->isEnabled()) {
+        $link = $candidate;
+        break;
       }
+    }
+    if (!$link) {
+      return [];
+    }
 
+    $ancestors = [];
+    $parent_id = $link->getParent();
+    while ($parent_id) {
       try {
-        $url_object = $link->getUrlObject();
-        $crumb = [
-          'title' => $link->getTitle(),
-          'url' => $url_object->toString(),
+        $parent = $this->menuLinkManager->createInstance($parent_id);
+        // A disabled ancestor hides the whole branch from the rendered menu,
+        // so the node has no visible trail.
+        if (!$parent->isEnabled()) {
+          return [];
+        }
+        $ancestors[] = [
+          'title' => $parent->getTitle(),
+          'url' => $parent->getUrlObject()->toString(),
         ];
+        $parent_id = $parent->getParent();
       }
       catch (\Exception $e) {
-        continue;
-      }
-
-      $current_path = $path;
-      $current_path[] = $crumb;
-
-      if ($this->linkPointsToNode($url_object, $target_nid)) {
-        return $current_path;
-      }
-
-      if (!empty($element->subtree)) {
-        $result = $this->searchTree($element->subtree, $target_nid, $current_path);
-        if ($result) {
-          return $result;
-        }
+        return [];
       }
     }
-    return NULL;
-  }
 
-  /**
-   * Checks whether a menu link URL points to a given node.
-   *
-   * @param \Drupal\Core\Url $url_object
-   *   The menu link URL object.
-   * @param string $target_nid
-   *   The node id to compare against.
-   *
-   * @return bool
-   *   TRUE when the URL is the canonical route of the target node.
-   */
-  protected function linkPointsToNode($url_object, string $target_nid): bool {
-    if (!$url_object->isRouted() || $url_object->getRouteName() !== 'entity.node.canonical') {
-      return FALSE;
-    }
-    $params = $url_object->getRouteParameters();
-    return isset($params['node']) && (string) $params['node'] === $target_nid;
+    return array_reverse($ancestors);
   }
 
   /**
@@ -410,10 +366,12 @@ class TideBreadcrumb {
    */
   public function getCacheTags(NodeInterface $node): array {
     $nid = $node->id() ?: 'new';
-    if (!isset($this->trails[$nid])) {
+    $site_term = $this->getViewingSite($node);
+    $cache_key = $nid . ':' . ($site_term ? $site_term->id() : 'none');
+    if (!isset($this->trailTags[$cache_key])) {
       $this->build($node);
     }
-    return array_unique($this->cacheTags);
+    return array_unique($this->trailTags[$cache_key] ?? []);
   }
 
   /**

--- a/tests/src/Kernel/TideBreadcrumbTest.php
+++ b/tests/src/Kernel/TideBreadcrumbTest.php
@@ -1,0 +1,242 @@
+<?php
+
+namespace Drupal\Tests\tide_core\Kernel;
+
+use Drupal\Core\Database\Database;
+use Drupal\field\Entity\FieldConfig;
+use Drupal\field\Entity\FieldStorageConfig;
+use Drupal\KernelTests\KernelTestBase;
+use Drupal\menu_link_content\Entity\MenuLinkContent;
+use Drupal\node\Entity\Node;
+use Drupal\node\Entity\NodeType;
+use Drupal\system\Entity\Menu;
+use Drupal\taxonomy\Entity\Term;
+use Drupal\taxonomy\Entity\Vocabulary;
+use Drupal\tide_core\TideBreadcrumb;
+
+/**
+ * Tests the tide_core breadcrumb builder.
+ *
+ * @coversDefaultClass \Drupal\tide_core\TideBreadcrumb
+ * @group tide_core
+ */
+class TideBreadcrumbTest extends KernelTestBase {
+
+  /**
+   * The modules to enable for this test.
+   *
+   * @var array
+   */
+  protected static $modules = [
+    'system',
+    'user',
+    'field',
+    'text',
+    'filter',
+    'node',
+    'taxonomy',
+    'link',
+    'menu_link_content',
+    'path_alias',
+  ];
+
+  /**
+   * Number of unrelated filler links seeded into the menu.
+   *
+   * Large enough that an implementation scaling with menu size fails the
+   * query budget in ::testBuildCostIsBoundedByTrailDepth by an order of
+   * magnitude.
+   *
+   * @var int
+   */
+  const FILLER_LINKS = 300;
+
+  /**
+   * The site term with breadcrumbs enabled.
+   *
+   * @var \Drupal\taxonomy\Entity\Term
+   */
+  protected $siteTerm;
+
+  /**
+   * Nodes keyed by role: grandparent, parent, target.
+   *
+   * @var \Drupal\node\Entity\Node[]
+   */
+  protected $nodes = [];
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp(): void {
+    parent::setUp();
+
+    $this->installEntitySchema('user');
+    $this->installEntitySchema('node');
+    $this->installEntitySchema('taxonomy_term');
+    $this->installEntitySchema('menu_link_content');
+    $this->installEntitySchema('path_alias');
+    $this->installSchema('node', ['node_access']);
+    $this->installConfig(['node', 'filter']);
+
+    NodeType::create(['type' => 'test', 'name' => 'Test'])->save();
+    Vocabulary::create(['vid' => 'sites', 'name' => 'Sites'])->save();
+    Menu::create(['id' => 'site-main', 'label' => 'Site main menu'])->save();
+
+    $this->createField('taxonomy_term', 'sites', 'field_enable_breadcrumbs', 'boolean');
+    $this->createField('taxonomy_term', 'sites', 'field_site_main_menu', 'entity_reference', ['target_type' => 'menu']);
+    $this->createField('node', 'test', 'field_node_primary_site', 'entity_reference', ['target_type' => 'taxonomy_term']);
+
+    $this->siteTerm = Term::create([
+      'vid' => 'sites',
+      'name' => 'Site A',
+      'field_enable_breadcrumbs' => 1,
+      'field_site_main_menu' => 'site-main',
+    ]);
+    $this->siteTerm->save();
+
+    // A three-level chain in the menu: Grandparent > Parent > Target.
+    foreach (['grandparent', 'parent', 'target'] as $name) {
+      $node = Node::create([
+        'type' => 'test',
+        'title' => ucfirst($name),
+        'status' => 1,
+        'field_node_primary_site' => $this->siteTerm->id(),
+      ]);
+      $node->save();
+      $this->nodes[$name] = $node;
+    }
+
+    $parent_plugin_id = NULL;
+    foreach ($this->nodes as $node) {
+      $link = MenuLinkContent::create([
+        'title' => $node->label(),
+        'link' => ['uri' => 'entity:node/' . $node->id()],
+        'menu_name' => 'site-main',
+        'parent' => $parent_plugin_id,
+        'enabled' => 1,
+      ]);
+      $link->save();
+      $parent_plugin_id = 'menu_link_content:' . $link->uuid();
+    }
+
+    // Filler links the builder must not pay for: top-level links to node
+    // routes that are not the target.
+    $filler_base_nid = $this->nodes['target']->id() + 1000;
+    for ($i = 0; $i < static::FILLER_LINKS; $i++) {
+      MenuLinkContent::create([
+        'title' => 'Filler ' . $i,
+        'link' => ['uri' => 'entity:node/' . ($filler_base_nid + $i)],
+        'menu_name' => 'site-main',
+        'enabled' => 1,
+      ])->save();
+    }
+
+    $this->container->get('router.builder')->rebuild();
+  }
+
+  /**
+   * Creates a field storage and instance pair.
+   */
+  protected function createField(string $entity_type, string $bundle, string $field_name, string $type, array $settings = []): void {
+    FieldStorageConfig::create([
+      'entity_type' => $entity_type,
+      'field_name' => $field_name,
+      'type' => $type,
+      'settings' => $settings,
+    ])->save();
+    FieldConfig::create([
+      'entity_type' => $entity_type,
+      'bundle' => $bundle,
+      'field_name' => $field_name,
+    ])->save();
+  }
+
+  /**
+   * Instantiates a fresh builder, bypassing its per-request static cache.
+   */
+  protected function createBuilder(): TideBreadcrumb {
+    return new TideBreadcrumb(
+      $this->container->get('plugin.manager.menu.link'),
+      $this->container->get('module_handler'),
+      $this->container->get('request_stack')
+    );
+  }
+
+  /**
+   * Tests the computed trail: Home plus menu ancestors, own link excluded.
+   *
+   * @covers ::build
+   */
+  public function testBuildTrail(): void {
+    $trail = $this->createBuilder()->build($this->nodes['target']);
+
+    $this->assertSame(['Home', 'Grandparent', 'Parent'], array_column($trail, 'title'));
+    $this->assertSame('/', $trail[0]['url']);
+    $this->assertStringContainsString('/node/' . $this->nodes['grandparent']->id(), $trail[1]['url']);
+    $this->assertStringContainsString('/node/' . $this->nodes['parent']->id(), $trail[2]['url']);
+  }
+
+  /**
+   * Tests that a top-level node gets only the Home crumb.
+   *
+   * @covers ::build
+   */
+  public function testBuildTrailTopLevelNode(): void {
+    $trail = $this->createBuilder()->build($this->nodes['grandparent']);
+    $this->assertSame(['Home'], array_column($trail, 'title'));
+  }
+
+  /**
+   * Tests that no trail is built when the site has breadcrumbs disabled.
+   *
+   * @covers ::build
+   */
+  public function testBuildTrailDisabledSite(): void {
+    $this->siteTerm->set('field_enable_breadcrumbs', 0)->save();
+    $node = $this->container->get('entity_type.manager')->getStorage('node')
+      ->loadUnchanged($this->nodes['target']->id());
+    $this->assertSame([], $this->createBuilder()->build($node));
+  }
+
+  /**
+   * Tests that build cost is bounded by trail depth, not menu size.
+   *
+   * Regression test for a performance issue where the builder generated a URL
+   * for every link in the menu while searching for the node: with the
+   * FILLER_LINKS unrelated links seeded in setUp(), that implementation issues
+   * hundreds of queries (one path alias lookup per link); a depth-bounded
+   * lookup needs only a handful.
+   *
+   * @covers ::build
+   */
+  public function testBuildCostIsBoundedByTrailDepth(): void {
+    Database::startLog('tide_breadcrumb');
+    $trail = $this->createBuilder()->build($this->nodes['target']);
+    $queries = Database::getLog('tide_breadcrumb');
+
+    $this->assertCount(3, $trail);
+    $this->assertLessThan(40, count($queries), sprintf(
+      'Building a depth-3 trail in a %d-link menu used %d queries; the cost must not scale with menu size.',
+      static::FILLER_LINKS + 3,
+      count($queries)
+    ));
+  }
+
+  /**
+   * Tests that cache tags are computed per node, not from the last build.
+   *
+   * @covers ::getCacheTags
+   */
+  public function testCacheTagsPerNode(): void {
+    $builder = $this->createBuilder();
+    $target_tags = $builder->getCacheTags($this->nodes['target']);
+    $parent_tags = $builder->getCacheTags($this->nodes['parent']);
+
+    $this->assertContains('node:' . $this->nodes['target']->id(), $target_tags);
+    $this->assertContains('config:system.menu.site-main', $target_tags);
+    $this->assertContains('node:' . $this->nodes['parent']->id(), $parent_tags);
+    $this->assertNotContains('node:' . $this->nodes['target']->id(), $parent_tags);
+  }
+
+}

--- a/tide_core.services.yml
+++ b/tide_core.services.yml
@@ -25,7 +25,7 @@ services:
   tide_core.breadcrumb:
     class: Drupal\tide_core\TideBreadcrumb
     arguments:
-      - '@menu.link_tree'
+      - '@plugin.manager.menu.link'
       - '@module_handler'
       - '@request_stack'
   tide_core.common_services:


### PR DESCRIPTION
## Problem

#797 introduced a per-node hot path that made JSON:API responses drastically slower on sites with large main menus:

- The computed `json_ld` field runs the metatag pipeline for **every node in every JSON:API response** (up to 50 per collection page).
- `TideBreadcrumb::searchTree()` loaded the site's **entire main menu tree** and called `getUrlObject()->toString()` — full URL generation with a path-alias DB lookup and tide_site outbound processing — on **every enabled link it visited, before checking whether the link matched the target node**. The generated URL was discarded for every non-matching link.

Cost: O(menu size) URL generations per node, × nodes per response. For a ~500-link menu that is ~25,000 URL generations on a 50-node collection page.

## Fix

- Replace the full-tree scan with `MenuLinkManager::loadLinksByRoute()` (one indexed query to find the node's link) and a walk up the parent chain, generating URLs **only for the ancestors that end up in the trail**. Cost is now O(trail depth) — ~100–150× less breadcrumb work per node on a large menu.
- Behaviour preserved: disabled links/branches hide the trail, the node's own link is excluded, "Home" leads the trail, and the per-site disable switch still bypasses `hook_tide_breadcrumb_alter()`.
- Fix `getCacheTags()` using a mismatched static-cache key (`$nid` vs `$nid:$site`), which also let cache tags from the last built node bleed into other nodes' tags. Tags are now cached per node+site key.
- Service now injects `@plugin.manager.menu.link` instead of `@menu.link_tree`.

## Tests

New `tests/src/Kernel/TideBreadcrumbTest.php`:

- Trail correctness (depth-3 chain, top-level node, breadcrumbs-disabled site).
- Per-node cache tags (regression for the tag-bleed bug).
- **Complexity regression test**: builds a depth-3 trail in a 303-link menu under a 40-query budget. The previous implementation issues 300+ queries (one alias lookup per link), so any future O(menu size) regression fails this test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
