### PR TITLE
[SD-1634] Added update hook to hide custom filters that does not have any component selected.

### DIFF
--- a/tide_core.install
+++ b/tide_core.install
@@ -5,6 +5,7 @@
  * Installation functions for Tide Core.
  */
 
+use Drupal\Core\Entity\Entity\EntityFormDisplay;
 use Drupal\field\Entity\FieldConfig;
 use Drupal\metatag\Entity\MetatagDefaults;
 use Drupal\node\Entity\Node;
@@ -1680,6 +1681,40 @@ function tide_core_update_10046() {
     if ($updated) {
       $metatag_settings->set('entity_type_groups', $entity_type_groups);
       $metatag_settings->save(TRUE);
+    }
+  }
+}
+
+/**
+ * Clean up Paragraph fields without handler settings from form displays.
+ */
+function tide_core_update_10047() {
+  /** @var \Drupal\field\Entity\FieldConfig[] $field_configs */
+  $field_configs = FieldConfig::loadMultiple();
+  $updated_displays = [];
+
+  foreach ($field_configs as $field_config) {
+    $handler = $field_config->getSetting('handler');
+    $handler_settings = $field_config->getSetting('handler_settings');
+
+    if ($handler === 'default:paragraph' && empty($handler_settings)) {
+      $entity_type = $field_config->getTargetEntityTypeId();
+      $bundle = $field_config->getTargetBundle();
+      $field_name = $field_config->getName();
+
+      // Explicit string concatenation
+      $form_display_id = $entity_type . '.' . $bundle . '.default';
+      
+      $form_display = EntityFormDisplay::load($form_display_id);
+
+      if ($form_display) {
+        $component = $form_display->getComponent($field_name);
+
+        if ($component !== NULL) {
+          $form_display->removeComponent($field_name);
+          $form_display->save();
+        }
+      }
     }
   }
 }

--- a/tide_core.install
+++ b/tide_core.install
@@ -1702,9 +1702,8 @@ function tide_core_update_10047() {
       $bundle = $field_config->getTargetBundle();
       $field_name = $field_config->getName();
 
-      // Explicit string concatenation
       $form_display_id = $entity_type . '.' . $bundle . '.default';
-      
+
       $form_display = EntityFormDisplay::load($form_display_id);
 
       if ($form_display) {


### PR DESCRIPTION
<!--
Please follow these rules:
1. SUBJECT: use format [SUPSSP-123] Verb in past tense with dot at the end.
   - This subject will be used as a commit message after PR is merged.
   - Verbs are usually one of these: Updated, Refactored, Removed, Changed, Added.
   - If there is no ticket - do not put [NOTICKET].

2. BODY: fill-in the template below

3. LABEL: Assign 'Needs review' label as soon as you ready to have this reviewed.

4. ASSIGNEE: Assign at least 2 reviewers.     

5. SLACK: Post a link to this PR to #developers channel.

No need to remove these lines - they are comments.
-->

**JIRA issue:** https://digital-vic.atlassian.net/browse/SD-1634
### Changed

1.  Added update hook to hide custom filters entity reference field from content types that does not have any component selected for the entity reference field.

### Screenshots

<!--
Provide as many screenshots as required to make reviewers understand what was changed.
-->